### PR TITLE
feat: split GPG-compat flags into a new tclig binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           mkdir -p dist
           cp target/${{ matrix.target }}/release/tcli dist/
+          cp target/${{ matrix.target }}/release/tclig dist/
           cp target/${{ matrix.target }}/release/tpass dist/
           cp completions/tpass.bash dist/
           cp completions/tpass.zsh dist/
@@ -83,6 +84,7 @@ jobs:
           tar xzf x86_64/tumpa-cli-x86_64-apple-darwin.tar.gz -C x86_64-bin
           tar xzf aarch64/tumpa-cli-aarch64-apple-darwin.tar.gz -C aarch64-bin
           lipo -create x86_64-bin/tcli aarch64-bin/tcli -output dist/tcli
+          lipo -create x86_64-bin/tclig aarch64-bin/tclig -output dist/tclig
           lipo -create x86_64-bin/tpass aarch64-bin/tpass -output dist/tpass
           cp aarch64-bin/tpass.bash dist/
           cp aarch64-bin/tpass.zsh dist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,7 +3307,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tumpa-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,15 @@ name = "tcli"
 path = "src/main.rs"
 
 [[bin]]
+name = "tclig"
+path = "src/tclig/main.rs"
+
+[[bin]]
 name = "tpass"
 path = "src/tpass/main.rs"
 
 [dependencies]
-wecanencrypt = { version = "0.10.0" , features = ["keystore", "card", "network"] }
+wecanencrypt = { version = "0.10.0", features = ["keystore", "card", "network"] }
 # Must match wecanencrypt's pgp dependency exactly -- both crates parse
 # detached signatures using pgp::composed::DetachedSignature, and a version
 # mismatch could cause parser disagreement (see verify.rs dual-parse note).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tumpa-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "OpenPGP operations and SSH agent backed by tumpa keystore."
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ The first step is importing your OpenPGP key. The keystore directory
 tcli --import my-secret-key.asc
 ```
 
+Already have keys in GnuPG? Import the whole keyring in one shot —
+both process substitution and stdin work, and multi-key streams
+are split into individual keys:
+
+```
+tcli --import <(gpg --export)          # all public keys from gpg
+gpg --export | tcli --import -         # same via a pipe
+gpg --export-secret-keys | tcli --import -
+```
+
 Verify it was imported:
 
 ```
@@ -226,6 +236,8 @@ For card operations, the PIN is requested the same way.
 ```
 tcli --import mykey.asc              # import from file
 tcli --import /path/to/keys/ -r      # import from directory (recursive)
+tcli --import <(gpg --export)        # migrate from gpg in one go
+gpg --export | tcli --import -       # or read keyring bytes from stdin
 tcli --export <FP> -o key.asc        # export (armored)
 tcli --info <FP>                     # detailed info for a keystore key
 tcli --desc mykey.asc                # detailed info for a key file (no import)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ A command-line tool for OpenPGP operations, SSH agent, and
 password management, backed by the
 [tumpa](https://github.com/tumpaproject/tumpa) keystore.
 
-Two binaries are provided:
+Three binaries are provided:
 
-- **`tcli`** -- drop-in GnuPG replacement for git signing, encryption/decryption,
-  key management, and SSH agent
+- **`tcli`** -- human-facing key management and SSH agent: import, export,
+  search, fetch, describe, list, delete, card status, agent daemons
+- **`tclig`** -- GnuPG drop-in for programs that invoke `gpg` (git signing,
+  `pass`, anything with a `gpg.program` hook)
 - **`tpass`** -- drop-in replacement for [password-store](https://www.passwordstore.org/)
   (`pass`), calling the tumpa keystore directly without GPG
 
@@ -16,6 +18,25 @@ stored in `~/.tumpa/keys.db`.
 
 For detailed usage instructions, see the
 [Usage Guide](https://github.com/tumpaproject/tumpa-cli/blob/main/docs/usage.md).
+
+## Upgrading from 0.1.x
+
+As of 0.2, the GPG drop-in flags (`-bsau`, `--verify`, `-e`, `-d`,
+`--list-keys --with-colons`, `--decrypt --list-only`, etc.) have
+moved out of `tcli` into a new binary **`tclig`**. `tcli` is now the
+human-facing key-management UI only.
+
+If you configured git with `gpg.program = tcli`, or symlinked
+`gpg2` to `tcli`, re-point them at `tclig`:
+
+```
+git config --global gpg.program tclig
+ln -sf $(which tclig) ~/bin/gpg2
+```
+
+Everything you typed at the `tcli` prompt as a human (`tcli
+--import`, `tcli --list-keys`, `tcli agent --ssh`, etc.) is
+unchanged.
 
 ## Features
 
@@ -39,7 +60,7 @@ For detailed usage instructions, see the
 cargo install tumpa-cli
 ```
 
-Two binaries are installed to `~/.cargo/bin/`: `tcli` and `tpass`.
+Three binaries are installed to `~/.cargo/bin/`: `tcli`, `tclig`, and `tpass`.
 
 ### System dependencies
 
@@ -94,10 +115,11 @@ tpass --completions fish > ~/.config/fish/completions/tpass.fish
 
 ### Git
 
-Configure git to use `tcli` for signing:
+Configure git to use `tclig` for signing (it's the GPG drop-in; `tcli`
+is the human-facing key manager and doesn't accept `gpg` flags):
 
 ```
-git config --global gpg.program tcli
+git config --global gpg.program tclig
 git config --global user.signingkey <FINGERPRINT>
 git config --global commit.gpgsign true
 ```
@@ -121,13 +143,13 @@ format (`~/.password-store/`). See the
 [Usage Guide](https://github.com/tumpaproject/tumpa-cli/blob/main/docs/usage.md#tpass--native-password-store)
 for full documentation.
 
-### password-store (`pass`) via tcli
+### password-store (`pass`) via tclig
 
-Alternatively, use the original `pass` with `tcli` as the GPG backend:
+Alternatively, use the original `pass` with `tclig` as the GPG backend:
 
 ```
 mkdir -p ~/bin
-ln -s $(which tcli) ~/bin/gpg2
+ln -s $(which tclig) ~/bin/gpg2
 export PATH="$HOME/bin:$PATH"
 pass init <FINGERPRINT>
 ```
@@ -156,23 +178,23 @@ below.
 
 ### Signing
 
-`tcli` is normally invoked by git, not directly. When git runs
-`gpg.program --detach-sign ...`, `tcli` handles it transparently.
+`tclig` is normally invoked by git, not directly. When git runs
+`gpg.program --detach-sign ...`, `tclig` handles it transparently.
 
 If a hardware OpenPGP card is connected and holds the signing key,
-`tcli` uses the card. Otherwise it uses the software key from the
+`tclig` uses the card. Otherwise it uses the software key from the
 tumpa keystore.
 
 ### Verification
 
-Git invokes `tcli --verify <sigfile> -` automatically for commands
+Git invokes `tclig --verify <sigfile> -` automatically for commands
 like `git verify-commit`, `git verify-tag`, and `git log --show-signature`.
 
 ### Encryption
 
 ```
-echo "secret" | tcli -e -r <FINGERPRINT> -o output.gpg
-tcli -e -r <FP1> -r <FP2> -o output.gpg input.txt
+echo "secret" | tclig -e -r <FINGERPRINT> -o output.gpg
+tclig -e -r <FP1> -r <FP2> -o output.gpg input.txt
 ```
 
 Multiple recipients are supported. Any recipient can decrypt.
@@ -180,8 +202,8 @@ Multiple recipients are supported. Any recipient can decrypt.
 ### Decryption
 
 ```
-tcli -d output.gpg             # decrypt to stdout
-tcli -d -o plaintext.txt file.gpg  # decrypt to file
+tclig -d output.gpg             # decrypt to stdout
+tclig -d -o plaintext.txt file.gpg  # decrypt to file
 ```
 
 The secret key is auto-detected from the encrypted message.
@@ -189,7 +211,7 @@ Decrypted output files are created with `0600` permissions.
 
 ### Passphrase / PIN entry
 
-`tcli` acquires passphrases in this order:
+Both `tcli` and `tclig` acquire passphrases in this order:
 
 1. **Agent cache** -- if `tcli agent` is running, cached passphrases
    are returned without prompting

--- a/docs/adr/0005-split-gpg-compat-binary.md
+++ b/docs/adr/0005-split-gpg-compat-binary.md
@@ -1,0 +1,188 @@
+# ADR 0005: Split GPG-compat Flags into a Separate `tclig` Binary
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-17
+
+## Context
+
+The `tcli` binary served two distinct audiences from a single entry
+point:
+
+1. **Humans** who run `tcli --import key.asc`, `tcli --list-keys`,
+   `tcli --desc file.asc`, `tcli --card-status`, `tcli agent`, etc.
+2. **Other programs** — `git` (via `git config gpg.program tcli`),
+   `pass` (via `ln -s tcli gpg2`), and anything else expecting a
+   GPG drop-in — that invoked `tcli` with flags like `-bsau`,
+   `--verify`, `-e`, `-d`, `--list-keys --with-colons`,
+   `--decrypt --list-only`, plus a large pile of accepted-and-
+   ignored compat flags (`--quiet`, `--yes`, `--batch`,
+   `--compress-algo`, `--no-encrypt-to`, `--keyid-format`,
+   `--status-fd`, `--default-key`, `--use-agent`, `--no-secmem-
+   warning`, `--no-permission-warning`, `-v`, `--list-config`).
+
+The two audiences disagreed on what flags mean and what `--help`
+should look like:
+
+- `--list-keys` alone is useful human output; `--list-keys
+  --with-colons` is the machine-parsed GnuPG colon format that
+  `pass` greps.
+- GPG-compat flags must be present so `pass` and `git` don't break,
+  but they clutter `tcli --help` for humans.
+- `src/cli.rs` had ~50 clap fields, roughly half of which existed
+  only because some external caller sent them.
+
+Hiding flags behind `#[clap(hide = true)]` reduces noise in
+`--help`, but every clap field still participates in the parser's
+disambiguation and error messages, and each one is another thing a
+human reading the codebase has to skip past when trying to
+understand the native CLI surface.
+
+## Decision
+
+Split `tumpa-cli` into two binaries within the same crate:
+
+- **`tcli`** — native, human-facing. Commands: `--import`,
+  `--export`, `--info`, `--desc`, `--delete`, `--search`,
+  `--fetch`, `--list-keys` (human-readable), `--card-status`,
+  `--show-socket`, `--completions`, `agent` / `ssh-agent` /
+  `ssh-export` subcommands, `--keystore`.
+
+- **`tclig`** — GPG drop-in, program-facing. Flags: `-b`, `-s`,
+  `-u`, `--verify`, `-e`, `-r`, `-d`, `-a`, `-o`, `--list-keys
+  --with-colons`, `--list-secret-keys --with-colons`,
+  `--decrypt --list-only`, `--list-config`, `--default-key`, plus
+  all 11 accepted-and-ignored compat flags, positional
+  `input_files`, `--keystore`, `--completions`.
+
+Layout:
+
+```
+src/
+  main.rs        tcli entry point
+  cli.rs         tcli clap Args + Mode
+  tclig/
+    main.rs      tclig entry point
+    cli.rs       tclig clap Args + Mode
+  tpass/         (unchanged)
+  gpg/           (unchanged — now only called from tclig)
+  store.rs, pinentry.rs, keystore.rs, agent/, ssh/, cache.rs
+                 (shared via lib.rs; both binaries use them)
+```
+
+`Cargo.toml` gains one `[[bin]]` entry:
+
+```toml
+[[bin]]
+name = "tclig"
+path = "src/tclig/main.rs"
+```
+
+### Shared flags are redeclared, not shared at the type level
+
+Both `Args` structs carry their own `--keystore`, `--output`,
+`--armor`, `--list-keys`, and positional `input_files`. The two
+parsers don't share a common base struct. This intentional
+duplication keeps each binary's CLI independent — `tcli`'s
+`--list-keys` means "human format"; `tclig`'s `--list-keys` means
+"GPG colon format". A shared base would force the same semantics on
+both.
+
+Code-wise, the dispatch targets (`store::*`, `pinentry::*`,
+`keystore::*`, `agent::*`, `ssh::*`, `gpg::*`) are all in `lib.rs`
+and reached via `tumpa_cli::*` from both binaries.
+
+### `src/gpg/` stays put, `tclig` calls into it
+
+The `gpg::sign`, `gpg::verify`, `gpg::encrypt`, `gpg::decrypt`,
+`gpg::keys` modules don't move. They continue to live under
+`src/gpg/` and are re-exposed via `pub mod gpg;` in `lib.rs`. Only
+the callers move: the eight dispatch arms that used to be in
+`src/main.rs` now live in `src/tclig/main.rs`. `tcli` no longer
+reaches into `tumpa_cli::gpg::*` at all.
+
+### `--verify` moves to `tclig` only (for now)
+
+Standalone `tcli --verify file.sig` was plausible for humans who
+wanted to verify a signature without `git`. We drop it from `tcli`
+in this change. A native `tcli --verify` can be reintroduced later
+if demand surfaces; it would share the same
+`gpg::verify::verify` function.
+
+## Consequences
+
+### Positive
+
+- `tcli --help` goes from ~50 flags to ~18. Humans reading it see
+  only the commands that are for them.
+- `tclig` is a stable, narrow GPG-compat surface. Future GPG-compat
+  additions (new ignored flags, new modes) don't touch the human
+  CLI.
+- Each binary has its own `name` in clap, which shows up correctly
+  in `--help` examples and generated shell completions.
+- `tests/test_pass.sh` symlinks `$TCLIG` as `gpg2`; the real-world
+  workload now exercises exactly the binary users will install.
+
+### Negative
+
+- Users upgrading who had `git config gpg.program tcli` or a `gpg2`
+  symlink pointing at `tcli` get "unknown option --verify" on next
+  use. A migration note at the top of `README.md` and a
+  Troubleshooting entry in `docs/usage.md` carry the fix: re-point
+  at `tclig`.
+- `Cargo.toml` grows one `[[bin]]`. `cargo build` compiles both.
+- Shared flags (`--keystore`, `--output`, `--armor`,
+  `--list-keys`, positional `input_files`) are declared in both
+  `Args` structs, not shared. Future additions to shared flags
+  need to touch both.
+- Shell completions must be generated for both binaries.
+  `tcli --completions <shell>` and `tclig --completions <shell>`
+  both exist; users have to run both if they want both.
+
+## Alternatives Considered
+
+### Single binary with a `gpg` subcommand (`tcli gpg -bsau …`)
+
+Would break `gpg.program` drop-in compatibility. `git`'s
+`gpg.program` is invoked with flags like `--detach-sign --armor -u
+… -bsau`, not with a leading `gpg` subcommand. Making it work
+would require a wrapper shell script or an `exec` shim, adding a
+new install artifact and failure mode.
+
+### Feature flag (`--features gpg-compat`)
+
+A compile-time toggle doesn't help at runtime — a published binary
+must always accept the GPG flags, because the user doesn't control
+the compilation. The problem is flag ergonomics, not binary size.
+
+### Keep everything in `tcli`, hide GPG flags with `#[clap(hide =
+true)]` (status quo)
+
+Already done for many of the ignored compat flags. `--help` is
+cleaner, but `cli.rs` still carries 50 fields; the parser still
+has to disambiguate them; reading the codebase is still noisy;
+error messages still reference the hidden flags when a typo
+matches one. Split solves all four.
+
+### Separate crate for `tclig`
+
+Keeping `tclig` in a sibling crate (`tclig/Cargo.toml`) would let
+it evolve independently. Rejected because it means a second
+`Cargo.toml` to maintain, a second path dep on `wecanencrypt`, and
+a second `cargo publish` step — for code that's tightly coupled to
+the keystore and pinentry plumbing in the existing `tumpa-cli`
+crate. A second `[[bin]]` in the same crate is much cheaper.
+
+## References
+
+- ADR 0001 (SSH Agent Support) — set the precedent for adding new
+  CLI surfaces as subcommands / bins within the same crate.
+- `tests/test_pass.sh` — the integration contract for GPG-compat
+  behaviour. After this change it symlinks `$TCLIG`, not `$TCLI`,
+  as `gpg2`.
+- `src/gpg/` — dispatch targets, unchanged by this split.
+- commit history of the `tclig`-split change for per-file diffs.

--- a/docs/adr/0006-import-from-gpg-and-stdin.md
+++ b/docs/adr/0006-import-from-gpg-and-stdin.md
@@ -1,0 +1,119 @@
+# ADR 0006: Import Directly From GnuPG and Stdin
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-17
+
+## Context
+
+Users migrating to `tcli` typically already have keys in GnuPG's
+keyring. The obvious migration path is `gpg --export` piped or
+process-substituted into `tcli --import`:
+
+```
+tcli --import <(gpg --export)
+gpg --export | tcli --import -
+```
+
+Two problems made this unreliable:
+
+1. **Multi-key blobs.** `gpg --export` (with no arguments) emits a
+   concatenated binary stream of every public key in the GnuPG
+   keyring. The previous `import_file` read the whole file,
+   called `wecanencrypt::parse_key_bytes` (single key), and passed
+   the raw bytes to `keystore.import_key` (also single key). Only
+   the first key landed in the tumpa keystore; the rest were
+   silently discarded.
+
+2. **Stdin wasn't wired.** `tcli --import` only accepted paths.
+   Piping keys in required a temporary file. Process substitution
+   (`<(gpg --export)`) happened to work because bash exposes the
+   pipe as `/dev/fd/N`, which `std::fs::read` can open — but that
+   still hit the single-key bug above.
+
+## Decision
+
+Rework `tcli --import` so a single invocation handles a stream of
+one or many OpenPGP keys, coming from files, directories, process
+substitution, or stdin.
+
+1. **Iterate with `pgp::composed::PublicOrSecret::from_reader_many`.**
+   The `rpgp` crate already provides a streaming parser that handles
+   mixed public/secret, armored/binary input and returns one key at
+   a time. `import_file` now reads the bytes, hands them to a new
+   `import_blob` helper, and that helper iterates every key in the
+   stream. Each key is serialized back to bytes (`to_writer`) and
+   passed through the existing single-key merge-or-import path.
+
+2. **Accept `-` as stdin.** `cmd_import` treats a path of `-` as
+   "read a keyring from stdin". An empty positional list also
+   defaults to stdin, so `gpg --export | tcli --import` works
+   without the trailing `-`.
+
+3. **Process substitution falls out for free.** `<(gpg --export)`
+   resolves to `/dev/fd/N`; `std::fs::read` opens that fd and reads
+   until EOF, and the new multi-key loop picks up every key in the
+   pipe.
+
+4. **Preserve existing behaviour for files and directories.** A
+   single-key `.asc`/`.pub`/`.gpg` file still follows the same
+   per-key merge-or-import logic, including the "Unchanged" /
+   "Updated — merged new signatures" messages from ADR 0002.
+   Directory recursion (`--import dir/ --recursive`) is unchanged.
+
+## Consequences
+
+### Positive
+
+- Migrating from GnuPG is a one-liner:
+  `tcli --import <(gpg --export)` or
+  `gpg --export | tcli --import`.
+- Keyring files with multiple keys (as produced by `gpg --export`,
+  `sq export`, `pg-pack`, or concatenation) are fully imported
+  instead of truncating after the first key.
+- Each key inside a multi-key stream participates in the existing
+  merge-on-duplicate flow (ADR 0002). Refreshing an entire
+  keyring's expiries is a single command.
+- Stdin support composes with Unix pipelines without a temporary
+  file (`curl ... | tcli --import -`).
+
+### Negative
+
+- A single malformed key inside an otherwise valid multi-key stream
+  is reported as failed and skipped; the remaining keys still
+  import. The final summary counts it under `failed`. We consider
+  this strictly better than aborting the whole import on one bad
+  key, and noisier than the previous silent truncation.
+- `from_reader_many` buffers the full input before iterating. For
+  very large keyrings this uses more memory than a true streaming
+  parser would, but in practice even a several-thousand-key GnuPG
+  ring is on the order of tens of MB.
+
+## Alternatives Considered
+
+### Extend `wecanencrypt::parse_keyring_bytes`
+
+`wecanencrypt` already exposes `parse_keyring_bytes`, but it only
+handles `SignedPublicKey::from_reader_many` and would reject a
+`gpg --export-secret-keys` stream. Using `PublicOrSecret::from_reader_many`
+directly in tumpa-cli handles both cases with no change to
+wecanencrypt.
+
+### Require an explicit `--stdin` flag
+
+Rejected. `-` as stdin is a universal Unix convention, and we
+already accept `input_files` positionally. Defaulting to stdin
+when no paths are given matches `gpg --import` behaviour, which
+users migrating from GnuPG already expect.
+
+### Split-and-loop at the tumpa-cli level
+
+We could have written our own "find the next key packet boundary"
+scanner to slice a multi-key blob into individual key byte slices.
+Rejected in favour of `from_reader_many`, which is already
+battle-tested inside `rpgp` and handles both armored and binary
+inputs uniformly.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,6 +115,26 @@ tcli --import my-secret-key.asc
 This imports both the secret key material and the public certificate.
 If `~/.tumpa/keys.db` doesn't exist yet, it is created automatically.
 
+### Migrate from GnuPG
+
+If your keys already live in GnuPG, feed `gpg --export` (or
+`gpg --export-secret-keys`) straight into `tcli --import`. The
+stream can contain many keys concatenated — every key is imported
+or merged:
+
+```
+tcli --import <(gpg --export)                # all public keys
+tcli --import <(gpg --export-secret-keys)    # public + secret material
+gpg --export | tcli --import -               # same via a pipe
+gpg --export | tcli --import                 # no path = read stdin
+```
+
+The process-substitution form (`<(...)`) works because bash exposes
+the pipe as `/dev/fd/N`, which `tcli` reads like any other file.
+Each key inside the stream runs through the same merge-on-duplicate
+flow as a single-file import — re-running the command later picks
+up renewed expiries and new certifications instead of duplicating.
+
 ### Verify the import
 
 ```
@@ -163,10 +183,19 @@ line or through the tumpa desktop application.
 ```
 tcli --import mykey.asc
 tcli --import /path/to/keys/ --recursive
+tcli --import <(gpg --export)                # process substitution
+gpg --export | tcli --import -               # stdin (explicit)
+gpg --export | tcli --import                 # stdin (implicit)
 ```
 
 Accepts armored and binary OpenPGP files. For directories, imports all
 `.asc`, `.gpg`, `.pub`, `.key`, `.pgp` files.
+
+A path of `-` (or no paths at all) reads a keyring from stdin. Any
+input — file, directory entry, process substitution, or stdin — may
+contain **multiple keys concatenated**, the shape `gpg --export`
+produces. Every key in the stream is imported or merged; a malformed
+key is reported and skipped without aborting the rest.
 
 When importing a key that already exists in the keystore, `tcli` merges
 the new data into the existing certificate instead of skipping it. This
@@ -178,6 +207,9 @@ what's already stored, the key is reported as "Unchanged".
 $ tcli --import updated_key.asc
 Updated A85FF376759C994A... (Alice <alice@example.com>) — merged new signatures
 ```
+
+See [ADR 0006](adr/0006-import-from-gpg-and-stdin.md) for the design
+rationale behind multi-key and stdin support.
 
 ### Fetching keys via WKD
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -253,12 +253,14 @@ Lines starting with `pub` are other people's public keys.
 
 ### GnuPG-compatible listing
 
-For scripts that parse GnuPG's colon-delimited output:
+For scripts that parse GnuPG's colon-delimited output, use `tclig`
+(the GPG drop-in binary — `tcli` is the human-facing UI and only
+emits the condensed `sec/pub fingerprint uid` format):
 
 ```
-tcli --list-keys --with-colons
-tcli --list-keys --with-colons <FINGERPRINT>
-tcli --list-secret-keys --with-colons
+tclig --list-keys --with-colons
+tclig --list-keys --with-colons <FINGERPRINT>
+tclig --list-secret-keys --with-colons
 ```
 
 ### Using a different keystore
@@ -279,10 +281,11 @@ export TUMPA_KEYSTORE=/path/to/other/keys.db
 
 ### One-time setup
 
-Tell git to use `tcli` instead of `gpg`:
+Tell git to use `tclig` instead of `gpg`. `tclig` is the GPG drop-in
+binary; the human-facing `tcli` does not accept `gpg` flags.
 
 ```
-git config --global gpg.program tcli
+git config --global gpg.program tclig
 ```
 
 Set your signing key (use the fingerprint from `tcli --list-keys`):
@@ -333,30 +336,30 @@ git log --pretty="format:%H %G?"
 
 ### How it works
 
-When git calls `tcli` for signing, it:
+When git calls `tclig` for signing, it:
 
 1. Checks if a connected OpenPGP card holds the signing key
 2. If yes, signs using the card (prompts for card PIN via pinentry)
 3. If no card, signs using the software key from the keystore
    (prompts for passphrase via pinentry)
 
-For verification, `tcli` looks up the signer's certificate in the
-keystore by fingerprint or key ID extracted from the signature.
+For verification, `tclig` looks up the signer's key in the keystore
+by fingerprint or key ID extracted from the signature.
 
 ### bump-tag compatibility
 
 [multiverse/bump-tag](https://github.com/SUNET/multiverse) works
-without any changes. `tcli` produces the `[GNUPG:]` status lines that
-git and bump-tag expect: `SIG_CREATED`, `GOODSIG`, `VALIDSIG`, and
-`TRUST_FULLY`.
+without any changes. `tclig` produces the `[GNUPG:]` status lines
+that git and bump-tag expect: `SIG_CREATED`, `GOODSIG`, `VALIDSIG`,
+and `TRUST_FULLY`.
 
 ---
 
 ## Password store (pass)
 
 [pass](https://www.passwordstore.org/) is the standard Unix password
-manager. It calls `gpg` for all encryption and decryption. `tcli` can
-replace `gpg` for `pass`.
+manager. It calls `gpg` for all encryption and decryption. `tclig`
+(the GPG drop-in binary) can replace `gpg` for `pass`.
 
 ### Setup
 
@@ -365,7 +368,7 @@ approach is to create a symlink:
 
 ```
 mkdir -p ~/bin
-ln -s $(which tcli) ~/bin/gpg2
+ln -s $(which tclig) ~/bin/gpg2
 ```
 
 Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
@@ -378,7 +381,7 @@ Alternatively, use an alias (works for interactive use but not all
 scripts):
 
 ```bash
-alias gpg2=tcli
+alias gpg2=tclig
 ```
 
 ### Initializing the store
@@ -415,7 +418,7 @@ echo "mypassword" | pass insert -m email/work
 pass email/work
 ```
 
-Prints the decrypted password to stdout. `tcli` automatically finds
+Prints the decrypted password to stdout. `tclig` automatically finds
 the right secret key and prompts for the passphrase via pinentry.
 
 ### Generating passwords
@@ -455,7 +458,7 @@ pass cp email/work email/backup  # copy
 
 When you change the keys in `.gpg-id` (via `pass init` with different
 fingerprints), `pass` reencrypts all passwords to the new set of keys.
-`tcli` supports the `--decrypt --list-only` and `--list-keys --with-colons`
+`tclig` supports the `--decrypt --list-only` and `--list-keys --with-colons`
 commands that `pass` uses to detect which files need reencryption.
 
 ---
@@ -652,7 +655,7 @@ section above.
 `tpass` is fully compatible with `pass`, with these differences:
 
 - **No GPG dependency** — `tpass` calls the tumpa keystore directly.
-  No need to symlink `tcli` as `gpg2` or configure `gpg.program`.
+  No need to symlink `tclig` as `gpg2` or configure `gpg.program`.
 - **Faster** — no process spawning overhead for GPG on each operation.
 - **Single binary** — `tpass` handles everything; no shell script.
 - **GPG groups not supported** — `pass` can expand GPG groups from
@@ -661,7 +664,7 @@ section above.
 
 ### Migrating from pass
 
-If you already have a password store set up with `pass` and `tcli` as
+If you already have a password store set up with `pass` and `tclig` as
 the GPG backend, switching to `tpass` requires no migration. Just use
 `tpass` instead of `pass` — the store format is identical:
 
@@ -680,33 +683,33 @@ Both commands read the same `~/.password-store/` directory and the same
 
 ## Encryption and decryption
 
-`tcli` can be used directly for encryption and decryption, outside of
-git or `pass`.
+`tclig` is the GPG drop-in, so encryption and decryption from the
+shell use the same flags `gpg` accepts.
 
 ### Encrypting
 
 Encrypt from stdin to a file:
 
 ```
-echo "secret data" | tcli -e -r <FINGERPRINT> -o secret.gpg
+echo "secret data" | tclig -e -r <FINGERPRINT> -o secret.gpg
 ```
 
 Encrypt a file:
 
 ```
-tcli -e -r <FINGERPRINT> -o document.gpg document.txt
+tclig -e -r <FINGERPRINT> -o document.gpg document.txt
 ```
 
 Encrypt to multiple recipients (any of them can decrypt):
 
 ```
-tcli -e -r <FP1> -r <FP2> -r <FP3> -o shared.gpg data.txt
+tclig -e -r <FP1> -r <FP2> -r <FP3> -o shared.gpg data.txt
 ```
 
 Produce ASCII-armored output:
 
 ```
-tcli -e -a -r <FINGERPRINT> -o secret.asc document.txt
+tclig -e -a -r <FINGERPRINT> -o secret.asc document.txt
 ```
 
 ### Decrypting
@@ -714,16 +717,16 @@ tcli -e -a -r <FINGERPRINT> -o secret.asc document.txt
 Decrypt to stdout:
 
 ```
-tcli -d secret.gpg
+tclig -d secret.gpg
 ```
 
 Decrypt to a file:
 
 ```
-tcli -d -o document.txt secret.gpg
+tclig -d -o document.txt secret.gpg
 ```
 
-`tcli` automatically determines which secret key can decrypt the
+`tclig` automatically determines which secret key can decrypt the
 message by inspecting the encrypted file's recipient key IDs. If your
 keystore contains the matching secret key, decryption proceeds after
 passphrase entry.
@@ -736,7 +739,7 @@ Output files from decryption are created with `0600` permissions
 To see which key IDs a file is encrypted for, without decrypting:
 
 ```
-tcli --decrypt --list-only encrypted.gpg
+tclig --decrypt --list-only encrypted.gpg
 ```
 
 Output:
@@ -759,9 +762,10 @@ passphrase prompts when signing commits, decrypting passwords, etc.
 tcli agent
 ```
 
-When the agent is running, `tcli` and `tpass` check it for cached
-passphrases before prompting via pinentry. Passphrases obtained from
-pinentry are automatically stored in the agent for reuse.
+When the agent is running, `tcli`, `tclig`, and `tpass` all check it
+for cached passphrases before prompting via pinentry. Passphrases
+obtained from pinentry are automatically stored in the agent for
+reuse.
 
 ### GPG + SSH agent
 
@@ -1139,16 +1143,17 @@ Common causes:
 
 ### git says "failed to sign the data"
 
-1. Check that `gpg.program` is set correctly:
+1. Check that `gpg.program` is set correctly (and points at `tclig`,
+   not `tcli` — `tcli` does not accept GPG flags):
 
    ```
    git config --global gpg.program
    ```
 
-2. Verify `tcli` can sign on its own:
+2. Verify `tclig` can sign on its own:
 
    ```
-   echo test | tcli -bsau <FINGERPRINT>
+   echo test | tclig -bsau <FINGERPRINT>
    ```
 
 3. Make sure `user.signingkey` matches a key in the keystore:
@@ -1158,18 +1163,29 @@ Common causes:
    tcli --list-keys
    ```
 
+### `gpg: unknown option --verify` after upgrading
+
+You have `git config gpg.program tcli`, or a `gpg2` symlink
+pointing at `tcli`. As of tumpa-cli 0.2 the GPG drop-in lives in a
+separate binary, `tclig`. Re-point the setting:
+
+```
+git config --global gpg.program tclig
+ln -sf $(which tclig) ~/bin/gpg2
+```
+
 ### Verifying the setup
 
 Quick end-to-end check:
 
 ```
 # Sign and verify
-echo "hello" | tcli -bsau <FP> > /tmp/test.sig
-echo "hello" | tcli --verify /tmp/test.sig -
+echo "hello" | tclig -bsau <FP> > /tmp/test.sig
+echo "hello" | tclig --verify /tmp/test.sig -
 
 # Encrypt and decrypt
-echo "secret" | tcli -e -r <FP> -o /tmp/test.gpg
-tcli -d /tmp/test.gpg
+echo "secret" | tclig -e -r <FP> -o /tmp/test.gpg
+tclig -d /tmp/test.gpg
 
 # Clean up
 rm /tmp/test.sig /tmp/test.gpg

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,78 +4,19 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap_complete::Shell;
 
-/// A GPG-compatible CLI for signing, verification, encryption, decryption,
-/// and SSH agent functionality, backed by the tumpa keystore.
+/// tcli — key management and SSH agent for the tumpa keystore.
 ///
-/// Designed as a drop-in replacement for GnuPG in git and password-store
-/// workflows. Tries hardware OpenPGP cards first, then falls back to
-/// software keys from ~/.tumpa/keys.db.
+/// Human-facing commands: import, export, describe, search, fetch,
+/// list, delete, card status, agent daemons, SSH pubkey export.
+/// For the GPG drop-in that git and pass invoke, see `tclig`.
 #[derive(Parser, Debug)]
-#[clap(name = "tcli")]
+#[clap(name = "tcli", version)]
 pub struct Args {
-    // --- Signing ---
-
-    /// Create a detached signature.
-    #[clap(long, short = 'b')]
-    pub detach_sign: bool,
-
-    /// Sign mode (accepted alongside --detach-sign).
-    #[clap(long, short = 's', hide = true)]
-    pub sign: bool,
-
-    /// Signing key fingerprint or key ID.
-    #[clap(long, short = 'u', value_names = ["SIGNING_KEY"])]
-    pub local_user: Option<String>,
-
-    // --- Verification ---
-
-    /// Verify a detached signature.
-    #[clap(long, value_names = ["SIGNATURE_FILE"])]
-    pub verify: Option<PathBuf>,
-
-    // --- Encryption ---
-
-    /// Encrypt mode.
-    #[clap(short = 'e', long)]
-    pub encrypt: bool,
-
-    /// Recipient key ID or fingerprint (may be repeated).
-    #[clap(short = 'r', long = "recipient")]
-    pub recipients: Vec<String>,
-
-    // --- Decryption ---
-
-    /// Decrypt mode.
-    #[clap(short = 'd', long)]
-    pub decrypt: bool,
-
-    // --- Output ---
-
-    /// Output ASCII-armored data.
-    #[clap(long, short = 'a')]
-    pub armor: bool,
-
-    /// Output file (for encrypt: required, for decrypt: optional, stdout if omitted).
-    #[clap(short = 'o', long = "output")]
-    pub output: Option<PathBuf>,
-
     // --- Key listing ---
 
-    /// List keys in the tumpa keystore.
+    /// List keys in the tumpa keystore (human-readable).
     #[clap(long)]
     pub list_keys: bool,
-
-    /// List secret keys in the tumpa keystore.
-    #[clap(long)]
-    pub list_secret_keys: bool,
-
-    /// Output in colon-delimited format (for --list-keys / --list-secret-keys).
-    #[clap(long)]
-    pub with_colons: bool,
-
-    /// List only metadata (used with --decrypt to inspect encrypted file).
-    #[clap(long)]
-    pub list_only: bool,
 
     // --- Key management ---
 
@@ -116,6 +57,16 @@ pub struct Args {
     #[clap(long)]
     pub card_status: bool,
 
+    // --- Output ---
+
+    /// Output ASCII-armored data (for --export).
+    #[clap(long, short = 'a')]
+    pub armor: bool,
+
+    /// Output file (for --export). Stdout if omitted.
+    #[clap(short = 'o', long = "output")]
+    pub output: Option<PathBuf>,
+
     /// Output in binary format (for --export).
     #[clap(long)]
     pub binary: bool,
@@ -138,7 +89,7 @@ pub struct Args {
 
     // --- Positional ---
 
-    /// Positional arguments (input files, "-" for stdin in verify mode).
+    /// Positional arguments (input files for --import).
     pub input_files: Vec<String>,
 
     // --- Keystore ---
@@ -158,49 +109,6 @@ pub struct Args {
     /// Generate shell completions and print to stdout.
     #[clap(long, value_name = "SHELL", value_enum)]
     pub completions: Option<Shell>,
-
-    // --- GPG compatibility flags (accepted, ignored) ---
-
-    #[clap(long, hide = true)]
-    pub keyid_format: Option<String>,
-
-    #[clap(long, hide = true)]
-    pub status_fd: Option<String>,
-
-    /// Default signing key (used by pass for --detach-sign).
-    #[clap(long, hide = true)]
-    pub default_key: Option<String>,
-
-    #[clap(long, short = 'q', hide = true)]
-    pub quiet: bool,
-
-    #[clap(long, hide = true)]
-    pub yes: bool,
-
-    #[clap(long, hide = true)]
-    pub compress_algo: Option<String>,
-
-    #[clap(long, hide = true)]
-    pub no_encrypt_to: bool,
-
-    #[clap(long, hide = true)]
-    pub batch: bool,
-
-    #[clap(long, hide = true)]
-    pub use_agent: bool,
-
-    #[clap(long, hide = true)]
-    pub no_secmem_warning: bool,
-
-    #[clap(long, hide = true)]
-    pub no_permission_warning: bool,
-
-    #[clap(short = 'v', hide = true)]
-    pub verbose: bool,
-
-    /// GPG --list-config (used by pass to query groups).
-    #[clap(long, hide = true)]
-    pub list_config: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -244,32 +152,7 @@ pub enum SubCommand {
 }
 
 pub enum Mode {
-    Sign {
-        signer_id: String,
-        armor: bool,
-    },
-    Verify {
-        signature_file: PathBuf,
-    },
-    Encrypt {
-        recipients: Vec<String>,
-        output: PathBuf,
-        input: Option<PathBuf>,
-        armor: bool,
-    },
-    Decrypt {
-        input: PathBuf,
-        output: Option<PathBuf>,
-    },
-    DecryptListOnly {
-        input: PathBuf,
-    },
-    ListKeysColon {
-        key_ids: Vec<String>,
-    },
-    ListSecretKeysColon,
     ListKeys,
-    ListConfig,
     Agent {
         ssh: bool,
         ssh_host: Option<String>,
@@ -416,94 +299,12 @@ impl TryFrom<Args> for Mode {
             });
         }
 
-        // --- GPG compatibility modes ---
+        // --- Key listing (human-readable; --with-colons form lives in tclig) ---
 
-        // --list-config (pass uses this to query GPG groups)
-        if value.list_config {
-            return Ok(Mode::ListConfig);
-        }
-
-        // --list-secret-keys --with-colons
-        if value.list_secret_keys {
-            return Ok(Mode::ListSecretKeysColon);
-        }
-
-        // --list-keys (with or without --with-colons)
         if value.list_keys {
-            if value.with_colons {
-                return Ok(Mode::ListKeysColon {
-                    key_ids: value.input_files,
-                });
-            }
             return Ok(Mode::ListKeys);
         }
 
-        // --decrypt --list-only FILE (metadata inspection)
-        if value.decrypt && value.list_only {
-            let input = value
-                .input_files
-                .first()
-                .map(PathBuf::from)
-                .ok_or("--decrypt --list-only requires an input file")?;
-            return Ok(Mode::DecryptListOnly { input });
-        }
-
-        // --encrypt
-        if value.encrypt {
-            if value.recipients.is_empty() {
-                return Err("Encryption requires at least one -r/--recipient".into());
-            }
-            let output = value
-                .output
-                .ok_or("Encryption requires -o/--output")?;
-            let input = value.input_files.first().map(PathBuf::from);
-            return Ok(Mode::Encrypt {
-                recipients: value.recipients,
-                output,
-                input,
-                armor: value.armor,
-            });
-        }
-
-        // --decrypt / -d
-        if value.decrypt {
-            let input = value
-                .input_files
-                .first()
-                .map(PathBuf::from)
-                .ok_or("Decryption requires an input file")?;
-            return Ok(Mode::Decrypt {
-                input,
-                output: value.output,
-            });
-        }
-
-        // --verify
-        if let Some(signature) = value.verify {
-            let has_stdin_marker = value.input_files.iter().any(|f| f == "-");
-            if has_stdin_marker {
-                Ok(Mode::Verify {
-                    signature_file: signature,
-                })
-            } else {
-                // pass calls: --verify FILE.sig FILE (two positional args, no "-")
-                // Also support this form
-                Ok(Mode::Verify {
-                    signature_file: signature,
-                })
-            }
-        } else if value.detach_sign || value.sign {
-            // Signing: -u is required, but --default-key can serve as fallback
-            let signer_id = value
-                .local_user
-                .or(value.default_key)
-                .ok_or("Signing requires -u or --default-key")?;
-            Ok(Mode::Sign {
-                signer_id,
-                armor: value.armor,
-            })
-        } else {
-            Ok(Mode::None)
-        }
+        Ok(Mode::None)
     }
 }

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -1,11 +1,21 @@
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use pgp::composed::PublicOrSecret;
+use pgp::ser::Serialize;
 
 use crate::store;
 
-/// Import keys from files or directories.
+/// Import keys from files, directories, or stdin.
+///
+/// A path of `-` (or no paths at all) means read an OpenPGP keyring from
+/// stdin. This makes `gpg --export | tcli --import -` and
+/// `tcli --import <(gpg --export)` both work: the former via explicit
+/// stdin, the latter via the `/dev/fd/N` path created by process
+/// substitution. Each stream may contain multiple keys concatenated
+/// (the default `gpg --export` shape) and every key in the stream is
+/// imported or merged.
 pub fn cmd_import(paths: &[PathBuf], recursive: bool, keystore_path: Option<&PathBuf>) -> Result<()> {
     log::debug!(
         "cmd_import: paths={} recursive={} keystore_path={:?}",
@@ -19,12 +29,24 @@ pub fn cmd_import(paths: &[PathBuf], recursive: bool, keystore_path: Option<&Pat
     let mut updated = 0u32;
     let mut failed = 0u32;
 
-    for path in paths {
-        log::debug!("cmd_import: processing {:?} (is_dir={})", path, path.is_dir());
-        if path.is_dir() {
-            import_dir(&keystore, path, recursive, &mut imported, &mut updated, &mut failed)?;
-        } else {
-            import_file(&keystore, path, &mut imported, &mut updated, &mut failed);
+    if paths.is_empty() {
+        import_stdin(&keystore, &mut imported, &mut updated, &mut failed);
+    } else {
+        for path in paths {
+            if is_stdin_path(path) {
+                import_stdin(&keystore, &mut imported, &mut updated, &mut failed);
+                continue;
+            }
+            log::debug!(
+                "cmd_import: processing {:?} (is_dir={})",
+                path,
+                path.is_dir()
+            );
+            if path.is_dir() {
+                import_dir(&keystore, path, recursive, &mut imported, &mut updated, &mut failed)?;
+            } else {
+                import_file(&keystore, path, &mut imported, &mut updated, &mut failed);
+            }
         }
     }
 
@@ -34,6 +56,28 @@ pub fn cmd_import(paths: &[PathBuf], recursive: bool, keystore_path: Option<&Pat
     );
     println!("Imported {} new, {} updated, {} failed.", imported, updated, failed);
     Ok(())
+}
+
+fn is_stdin_path(path: &Path) -> bool {
+    path.as_os_str() == "-"
+}
+
+fn import_stdin(
+    keystore: &wecanencrypt::KeyStore,
+    imported: &mut u32,
+    updated: &mut u32,
+    failed: &mut u32,
+) {
+    log::debug!("import_stdin: reading keyring from stdin");
+    let mut data = Vec::new();
+    if let Err(e) = io::stdin().read_to_end(&mut data) {
+        log::error!("import_stdin: read failed: {:#}", e);
+        eprintln!("Failed to read from stdin: {:#}", e);
+        *failed += 1;
+        return;
+    }
+    log::debug!("import_stdin: read {} bytes", data.len());
+    import_blob(keystore, &data, "<stdin>", imported, updated, failed);
 }
 
 fn import_dir(
@@ -90,12 +134,80 @@ fn import_file(
     };
     log::debug!("import_file: read {} bytes from {:?}", data.len(), path);
 
+    let label = path.display().to_string();
+    import_blob(keystore, &data, &label, imported, updated, failed);
+}
+
+/// Parse a blob that may contain one or many OpenPGP keys (public,
+/// secret, or mixed, armored or binary) and import each key
+/// individually. `gpg --export` produces a concatenated stream of all
+/// exported keys; iterating with `PublicOrSecret::from_reader_many`
+/// imports every key in the stream instead of silently stopping at
+/// the first one.
+fn import_blob(
+    keystore: &wecanencrypt::KeyStore,
+    data: &[u8],
+    source_label: &str,
+    imported: &mut u32,
+    updated: &mut u32,
+    failed: &mut u32,
+) {
+    let cursor = io::Cursor::new(data);
+    let iter = match PublicOrSecret::from_reader_many(cursor) {
+        Ok((iter, _headers)) => iter,
+        Err(e) => {
+            log::error!("import_blob: parse_many failed for {}: {:#}", source_label, e);
+            eprintln!("Failed to parse keys from {}: {:#}", source_label, e);
+            *failed += 1;
+            return;
+        }
+    };
+
+    let mut any_key = false;
+    for key_result in iter {
+        any_key = true;
+        let key = match key_result {
+            Ok(k) => k,
+            Err(e) => {
+                log::error!("import_blob: key parse failed in {}: {:#}", source_label, e);
+                eprintln!("Failed to parse a key from {}: {:#}", source_label, e);
+                *failed += 1;
+                continue;
+            }
+        };
+
+        let mut key_bytes = Vec::new();
+        if let Err(e) = key.to_writer(&mut key_bytes) {
+            log::error!("import_blob: serialize failed in {}: {:#}", source_label, e);
+            eprintln!("Failed to re-serialize key from {}: {:#}", source_label, e);
+            *failed += 1;
+            continue;
+        }
+
+        import_one_key(keystore, &key_bytes, source_label, imported, updated, failed);
+    }
+
+    if !any_key {
+        log::debug!("import_blob: no keys found in {}", source_label);
+        eprintln!("No OpenPGP keys found in {}", source_label);
+        *failed += 1;
+    }
+}
+
+fn import_one_key(
+    keystore: &wecanencrypt::KeyStore,
+    data: &[u8],
+    source_label: &str,
+    imported: &mut u32,
+    updated: &mut u32,
+    failed: &mut u32,
+) {
     // If the key already exists, merge new signatures into the stored key
-    match wecanencrypt::parse_key_bytes(&data, false) {
+    match wecanencrypt::parse_key_bytes(data, false) {
         Ok(key_info) => {
             log::debug!(
-                "import_file: parsed {:?} fp={} secret={} uids={} subkeys={}",
-                path,
+                "import_one_key: parsed from {} fp={} secret={} uids={} subkeys={}",
+                source_label,
                 key_info.fingerprint,
                 key_info.is_secret,
                 key_info.user_ids.len(),
@@ -103,12 +215,12 @@ fn import_file(
             );
             let already_present = match keystore.contains(&key_info.fingerprint) {
                 Ok(b) => {
-                    log::debug!("import_file: contains({})={}", key_info.fingerprint, b);
+                    log::debug!("import_one_key: contains({})={}", key_info.fingerprint, b);
                     b
                 }
                 Err(e) => {
                     log::error!(
-                        "import_file: contains({}) failed: {:#}",
+                        "import_one_key: contains({}) failed: {:#}",
                         key_info.fingerprint,
                         e,
                     );
@@ -121,20 +233,20 @@ fn import_file(
                     .first()
                     .map(|u| u.value.as_str())
                     .unwrap_or("");
-                match merge_and_reimport(keystore, &key_info.fingerprint, &data) {
+                match merge_and_reimport(keystore, &key_info.fingerprint, data) {
                     Ok(true) => {
-                        log::info!("import_file: merged fp={} (changed)", key_info.fingerprint);
+                        log::info!("import_one_key: merged fp={} (changed)", key_info.fingerprint);
                         println!("Updated {} ({}) — merged new signatures", key_info.fingerprint, uid);
                         *updated += 1;
                     }
                     Ok(false) => {
-                        log::info!("import_file: merged fp={} (no change)", key_info.fingerprint);
+                        log::info!("import_one_key: merged fp={} (no change)", key_info.fingerprint);
                         println!("Unchanged {} ({}) — no new data", key_info.fingerprint, uid);
                         *updated += 1;
                     }
                     Err(e) => {
-                        log::error!("import_file: merge failed for {:?}: {:#}", path, e);
-                        eprintln!("Failed to merge {:?}: {:#}", path, e);
+                        log::error!("import_one_key: merge failed for {}: {:#}", source_label, e);
+                        eprintln!("Failed to merge key from {}: {:#}", source_label, e);
                         *failed += 1;
                     }
                 }
@@ -143,26 +255,26 @@ fn import_file(
         }
         Err(e) => {
             log::debug!(
-                "import_file: parse_key_bytes failed for {:?}: {:#} (falling through to raw import)",
-                path,
+                "import_one_key: parse_key_bytes failed for {}: {:#} (falling through to raw import)",
+                source_label,
                 e,
             );
         }
     }
 
-    match keystore.import_key(&data) {
+    match keystore.import_key(data) {
         Ok(fp) => {
             let info = keystore.get_key_info(&fp).ok();
             let uid = info
                 .and_then(|i| i.user_ids.first().map(|u| u.value.clone()))
                 .unwrap_or_default();
-            log::info!("import_file: imported fp={}", fp);
+            log::info!("import_one_key: imported fp={}", fp);
             println!("Imported {} ({})", fp, uid);
             *imported += 1;
         }
         Err(e) => {
-            log::error!("import_file: import_key failed for {:?}: {:#}", path, e);
-            eprintln!("Failed to import {:?}: {:#}", path, e);
+            log::error!("import_one_key: import_key failed for {}: {:#}", source_label, e);
+            eprintln!("Failed to import key from {}: {:#}", source_label, e);
             *failed += 1;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod cli;
 
-use std::io::{stderr, stdin, stdout};
+use std::io::stdout;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use tumpa_cli::{gpg, keystore, pinentry, ssh, store};
+use tumpa_cli::{keystore, pinentry, ssh, store};
 
 use cli::*;
 
@@ -15,46 +15,6 @@ fn main() {
     let keystore_path = args.keystore.clone();
 
     let res = match Mode::try_from(args) {
-        Ok(Mode::Sign { signer_id, armor }) => gpg::sign::sign(
-            stdin(),
-            stdout(),
-            stderr(),
-            &signer_id,
-            armor,
-            keystore_path.as_ref(),
-        ),
-        Ok(Mode::Verify { signature_file }) => gpg::verify::verify(
-            stdin(),
-            stdout(),
-            stderr(),
-            &signature_file,
-            keystore_path.as_ref(),
-        ),
-        Ok(Mode::Encrypt {
-            recipients,
-            output,
-            input,
-            armor,
-        }) => gpg::encrypt::encrypt(
-            input.as_ref(),
-            &output,
-            &recipients,
-            armor,
-            keystore_path.as_ref(),
-        ),
-        Ok(Mode::Decrypt { input, output }) => {
-            gpg::decrypt::decrypt(&input, output.as_ref(), keystore_path.as_ref())
-        }
-        Ok(Mode::DecryptListOnly { input }) => {
-            gpg::decrypt::decrypt_list_only(&input, keystore_path.as_ref())
-        }
-        Ok(Mode::ListKeysColon { key_ids }) => {
-            gpg::keys::list_keys_colon(&key_ids, keystore_path.as_ref())
-        }
-        Ok(Mode::ListSecretKeysColon) => {
-            gpg::keys::list_secret_keys_colon(keystore_path.as_ref())
-        }
-        Ok(Mode::ListConfig) => gpg::keys::list_config(),
         Ok(Mode::ListKeys) => list_keys(keystore_path.as_ref()),
         Ok(Mode::Agent {
             ssh,
@@ -133,22 +93,16 @@ fn print_help() {
         .unwrap_or_else(|| "tcli".to_string());
 
     eprintln!(
-        "tcli - GPG replacement and SSH agent backed by tumpa keystore
+                "tcli - key management and SSH agent backed by tumpa keystore
 
-To use with git:
+For git signing and pass integration, use `tclig` as the GPG drop-in:
 
-  $ git config --global gpg.program {exe}
-  $ git config --global user.signingkey <FINGERPRINT>
-  $ git config --global commit.gpgsign true
-
-To use with pass (password-store):
-
-  $ alias gpg={exe}
-  $ pass init <FINGERPRINT>
+    $ git config --global gpg.program tclig
+    $ ln -sf $(which tclig) ~/bin/gpg2
 
 To list keys in the keystore:
 
-  $ tcli --list-keys
+    $ {exe} --list-keys
 
 Keys are stored in ~/.tumpa/keys.db (managed by the tumpa desktop app).
 Hardware OpenPGP cards are tried first, then software keys from the keystore."

--- a/src/tclig/cli.rs
+++ b/src/tclig/cli.rs
@@ -1,0 +1,262 @@
+use std::convert::TryFrom;
+use std::path::PathBuf;
+
+use clap::Parser;
+use clap_complete::Shell;
+
+/// tclig — a GPG drop-in for git, pass, and anything else that
+/// expects a `gpg.program` binary. Backed by the tumpa keystore.
+///
+/// Most users never invoke `tclig` directly; they point
+/// `git config gpg.program tclig` or symlink `gpg2` to `tclig`.
+/// For human-facing key management see `tcli` instead.
+#[derive(Parser, Debug)]
+#[clap(name = "tclig", version)]
+pub struct Args {
+    // --- Signing ---
+
+    /// Create a detached signature.
+    #[clap(long, short = 'b')]
+    pub detach_sign: bool,
+
+    /// Sign mode (accepted alongside --detach-sign).
+    #[clap(long, short = 's', hide = true)]
+    pub sign: bool,
+
+    /// Signing key fingerprint or key ID.
+    #[clap(long, short = 'u', value_names = ["SIGNING_KEY"])]
+    pub local_user: Option<String>,
+
+    // --- Verification ---
+
+    /// Verify a detached signature.
+    #[clap(long, value_names = ["SIGNATURE_FILE"])]
+    pub verify: Option<PathBuf>,
+
+    // --- Encryption ---
+
+    /// Encrypt mode.
+    #[clap(short = 'e', long)]
+    pub encrypt: bool,
+
+    /// Recipient key ID or fingerprint (may be repeated).
+    #[clap(short = 'r', long = "recipient")]
+    pub recipients: Vec<String>,
+
+    // --- Decryption ---
+
+    /// Decrypt mode.
+    #[clap(short = 'd', long)]
+    pub decrypt: bool,
+
+    // --- Output ---
+
+    /// Output ASCII-armored data.
+    #[clap(long, short = 'a')]
+    pub armor: bool,
+
+    /// Output file (for encrypt: required, for decrypt: optional, stdout if omitted).
+    #[clap(short = 'o', long = "output")]
+    pub output: Option<PathBuf>,
+
+    // --- Key listing ---
+
+    /// List keys in the tumpa keystore (GPG colon format).
+    #[clap(long)]
+    pub list_keys: bool,
+
+    /// List secret keys in the tumpa keystore (GPG colon format).
+    #[clap(long)]
+    pub list_secret_keys: bool,
+
+    /// Output in colon-delimited format (for --list-keys / --list-secret-keys).
+    #[clap(long)]
+    pub with_colons: bool,
+
+    /// List only metadata (used with --decrypt to inspect encrypted file).
+    #[clap(long)]
+    pub list_only: bool,
+
+    // --- Positional ---
+
+    /// Positional arguments: input files, or "-" for stdin in verify mode.
+    pub input_files: Vec<String>,
+
+    // --- Keystore ---
+
+    /// Path to tumpa keystore database. Defaults to ~/.tumpa/keys.db.
+    #[clap(long, env = "TUMPA_KEYSTORE")]
+    pub keystore: Option<PathBuf>,
+
+    // --- Shell completions ---
+
+    /// Generate shell completions and print to stdout.
+    #[clap(long, value_name = "SHELL", value_enum)]
+    pub completions: Option<Shell>,
+
+    // --- GPG compatibility flags (accepted, ignored) ---
+
+    #[clap(long, hide = true)]
+    pub keyid_format: Option<String>,
+
+    #[clap(long, hide = true)]
+    pub status_fd: Option<String>,
+
+    /// Default signing key (used by pass for --detach-sign).
+    #[clap(long, hide = true)]
+    pub default_key: Option<String>,
+
+    #[clap(long, short = 'q', hide = true)]
+    pub quiet: bool,
+
+    #[clap(long, hide = true)]
+    pub yes: bool,
+
+    #[clap(long, hide = true)]
+    pub compress_algo: Option<String>,
+
+    #[clap(long, hide = true)]
+    pub no_encrypt_to: bool,
+
+    #[clap(long, hide = true)]
+    pub batch: bool,
+
+    #[clap(long, hide = true)]
+    pub use_agent: bool,
+
+    #[clap(long, hide = true)]
+    pub no_secmem_warning: bool,
+
+    #[clap(long, hide = true)]
+    pub no_permission_warning: bool,
+
+    #[clap(short = 'v', hide = true)]
+    pub verbose: bool,
+
+    /// GPG --list-config (used by pass to query groups).
+    #[clap(long, hide = true)]
+    pub list_config: bool,
+}
+
+pub enum Mode {
+    Sign {
+        signer_id: String,
+        armor: bool,
+    },
+    Verify {
+        signature_file: PathBuf,
+    },
+    Encrypt {
+        recipients: Vec<String>,
+        output: PathBuf,
+        input: Option<PathBuf>,
+        armor: bool,
+    },
+    Decrypt {
+        input: PathBuf,
+        output: Option<PathBuf>,
+    },
+    DecryptListOnly {
+        input: PathBuf,
+    },
+    ListKeysColon {
+        key_ids: Vec<String>,
+    },
+    ListSecretKeysColon,
+    ListConfig,
+    Completions {
+        shell: Shell,
+    },
+    None,
+}
+
+impl TryFrom<Args> for Mode {
+    type Error = String;
+
+    fn try_from(value: Args) -> Result<Self, Self::Error> {
+        // --- Shell completions ---
+
+        if let Some(shell) = value.completions {
+            return Ok(Mode::Completions { shell });
+        }
+
+        // --- GPG compatibility modes ---
+
+        // --list-config (pass uses this to query GPG groups)
+        if value.list_config {
+            return Ok(Mode::ListConfig);
+        }
+
+        // --list-secret-keys --with-colons
+        if value.list_secret_keys {
+            return Ok(Mode::ListSecretKeysColon);
+        }
+
+        // --list-keys (always colon format in tclig)
+        if value.list_keys {
+            return Ok(Mode::ListKeysColon {
+                key_ids: value.input_files,
+            });
+        }
+
+        // --decrypt --list-only FILE (metadata inspection)
+        if value.decrypt && value.list_only {
+            let input = value
+                .input_files
+                .first()
+                .map(PathBuf::from)
+                .ok_or("--decrypt --list-only requires an input file")?;
+            return Ok(Mode::DecryptListOnly { input });
+        }
+
+        // --encrypt
+        if value.encrypt {
+            if value.recipients.is_empty() {
+                return Err("Encryption requires at least one -r/--recipient".into());
+            }
+            let output = value.output.ok_or("Encryption requires -o/--output")?;
+            let input = value.input_files.first().map(PathBuf::from);
+            return Ok(Mode::Encrypt {
+                recipients: value.recipients,
+                output,
+                input,
+                armor: value.armor,
+            });
+        }
+
+        // --decrypt / -d
+        if value.decrypt {
+            let input = value
+                .input_files
+                .first()
+                .map(PathBuf::from)
+                .ok_or("Decryption requires an input file")?;
+            return Ok(Mode::Decrypt {
+                input,
+                output: value.output,
+            });
+        }
+
+        // --verify
+        if let Some(signature) = value.verify {
+            return Ok(Mode::Verify {
+                signature_file: signature,
+            });
+        }
+
+        // -b / -s (signing)
+        if value.detach_sign || value.sign {
+            // Signing: -u is required, but --default-key can serve as fallback
+            let signer_id = value
+                .local_user
+                .or(value.default_key)
+                .ok_or("Signing requires -u or --default-key")?;
+            return Ok(Mode::Sign {
+                signer_id,
+                armor: value.armor,
+            });
+        }
+
+        Ok(Mode::None)
+    }
+}

--- a/src/tclig/main.rs
+++ b/src/tclig/main.rs
@@ -1,0 +1,103 @@
+mod cli;
+
+use std::io::{stderr, stdin, stdout};
+
+use clap::{CommandFactory, Parser};
+use clap_complete::generate;
+use tumpa_cli::gpg;
+
+use cli::*;
+
+fn main() {
+    env_logger::builder().format_timestamp_micros().init();
+
+    let args = Args::parse();
+    let keystore_path = args.keystore.clone();
+
+    let res = match Mode::try_from(args) {
+        Ok(Mode::Sign { signer_id, armor }) => gpg::sign::sign(
+            stdin(),
+            stdout(),
+            stderr(),
+            &signer_id,
+            armor,
+            keystore_path.as_ref(),
+        ),
+        Ok(Mode::Verify { signature_file }) => gpg::verify::verify(
+            stdin(),
+            stdout(),
+            stderr(),
+            &signature_file,
+            keystore_path.as_ref(),
+        ),
+        Ok(Mode::Encrypt {
+            recipients,
+            output,
+            input,
+            armor,
+        }) => gpg::encrypt::encrypt(
+            input.as_ref(),
+            &output,
+            &recipients,
+            armor,
+            keystore_path.as_ref(),
+        ),
+        Ok(Mode::Decrypt { input, output }) => {
+            gpg::decrypt::decrypt(&input, output.as_ref(), keystore_path.as_ref())
+        }
+        Ok(Mode::DecryptListOnly { input }) => {
+            gpg::decrypt::decrypt_list_only(&input, keystore_path.as_ref())
+        }
+        Ok(Mode::ListKeysColon { key_ids }) => {
+            gpg::keys::list_keys_colon(&key_ids, keystore_path.as_ref())
+        }
+        Ok(Mode::ListSecretKeysColon) => gpg::keys::list_secret_keys_colon(keystore_path.as_ref()),
+        Ok(Mode::ListConfig) => gpg::keys::list_config(),
+        Ok(Mode::Completions { shell }) => {
+            generate(shell, &mut Args::command(), "tclig", &mut stdout());
+            Ok(())
+        }
+        Ok(Mode::None) => {
+            print_help();
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = res {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn print_help() {
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(String::from))
+        .unwrap_or_else(|| "tclig".to_string());
+
+    eprintln!(
+        "tclig - GPG drop-in backed by the tumpa keystore
+
+Invoked by git, pass, and anything else that expects a `gpg.program`.
+For human-facing key management use `tcli` instead.
+
+To use with git:
+
+  $ git config --global gpg.program {exe}
+  $ git config --global user.signingkey <FINGERPRINT>
+  $ git config --global commit.gpgsign true
+
+To use with pass (password-store):
+
+  $ ln -s {exe} ~/bin/gpg2
+  $ pass init <FINGERPRINT>
+
+Keys are stored in ~/.tumpa/keys.db (managed by the tumpa desktop app
+or `tcli --import`). Hardware OpenPGP cards are tried first, then
+software keys from the keystore."
+    );
+}

--- a/tests/test_keystore.sh
+++ b/tests/test_keystore.sh
@@ -97,8 +97,9 @@ echo "[1] Import"
 run_test "import single file" "$TCLI" --import "$KEYS_DIR/public.asc"
 test_output_contains "import reports count" "Imported 1" "$TCLI" --import "$KEYS_DIR/hellopublic.asc"
 
-# Import same file again — should merge (no new data, but reports as updated)
-test_output_contains "import re-import merges" "Updated $FP_PUBLIC" "$TCLI" --import "$KEYS_DIR/public.asc"
+# Import same file again — merge is idempotent, so a byte-identical
+# re-import reports "Unchanged" (still counted under the updated tally).
+test_output_contains "import re-import unchanged" "Unchanged $FP_PUBLIC" "$TCLI" --import "$KEYS_DIR/public.asc"
 test_output_contains "import re-import reports count" "0 new, 1 updated" "$TCLI" --import "$KEYS_DIR/public.asc"
 
 # Import from directory

--- a/tests/test_pass.sh
+++ b/tests/test_pass.sh
@@ -19,9 +19,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TCLI="$PROJECT_DIR/target/debug/tcli"
+TCLIG="$PROJECT_DIR/target/debug/tclig"
 
 if [[ ! -x "$TCLI" ]]; then
     echo "ERROR: tcli not found at $TCLI"
+    echo "Run 'cargo build' first."
+    exit 1
+fi
+
+if [[ ! -x "$TCLIG" ]]; then
+    echo "ERROR: tclig not found at $TCLIG"
     echo "Run 'cargo build' first."
     exit 1
 fi
@@ -60,8 +67,8 @@ export PASSWORD_STORE_DIR="$TEST_DIR/store"
 WRAPPER_DIR="$TEST_DIR/bin"
 
 mkdir -p "$WRAPPER_DIR"
-ln -sf "$TCLI" "$WRAPPER_DIR/gpg2"
-ln -sf "$TCLI" "$WRAPPER_DIR/gpg"
+ln -sf "$TCLIG" "$WRAPPER_DIR/gpg2"
+ln -sf "$TCLIG" "$WRAPPER_DIR/gpg"
 export PATH="$WRAPPER_DIR:$PATH"
 
 PASS_COUNT=0
@@ -173,7 +180,7 @@ fi
 echo ""
 echo "[10] Key listing (GPG compat)"
 echo -n "  --list-keys --with-colons (encryption subkey) ... "
-SUB_E=$("$TCLI" --list-keys --with-colons "$KEY_FP" 2>/dev/null \
+SUB_E=$("$TCLIG" --list-keys --with-colons "$KEY_FP" 2>/dev/null \
     | sed -n 's/^sub:[^idr:]*:[^:]*:[^:]*:\([^:]*\):[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:[a-zA-Z]*e[a-zA-Z]*:.*/\1/p')
 if [[ -n "$SUB_E" ]]; then
     echo "OK ($SUB_E)"
@@ -184,7 +191,7 @@ else
 fi
 
 echo -n "  --list-secret-keys --with-colons (UID) ... "
-UID_LINE=$("$TCLI" --list-secret-keys --with-colons 2>/dev/null \
+UID_LINE=$("$TCLIG" --list-secret-keys --with-colons 2>/dev/null \
     | grep "^uid:" | head -1 | cut -d: -f10)
 if [[ -n "$UID_LINE" ]]; then
     echo "OK ($UID_LINE)"
@@ -195,7 +202,7 @@ else
 fi
 
 echo -n "  --decrypt --list-only ... "
-PUBKEY=$("$TCLI" --decrypt --list-only "$PASSWORD_STORE_DIR/test/multi.gpg" 2>&1 \
+PUBKEY=$("$TCLIG" --decrypt --list-only "$PASSWORD_STORE_DIR/test/multi.gpg" 2>&1 \
     | sed -nE 's/^gpg: public key is ([A-F0-9]+)$/\1/p')
 if [[ -n "$PUBKEY" ]]; then
     echo "OK ($PUBKEY)"

--- a/tests/test_tpass_compat.sh
+++ b/tests/test_tpass_compat.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Cross-compatibility test: verify tpass and pass (with tcli as GPG) interoperate.
+# Cross-compatibility test: verify tpass and pass (with tclig as GPG) interoperate.
 #
 # Prerequisites:
-#   - tpass and tcli built (cargo build)
+#   - tpass, tcli, and tclig built (cargo build)
 #   - pass installed
 #   - At least one secret key with an encryption subkey in ~/.tumpa/keys.db
 #   - TUMPA_PASSPHRASE set for non-interactive testing
@@ -16,9 +16,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TPASS="$PROJECT_DIR/target/debug/tpass"
 TCLI="$PROJECT_DIR/target/debug/tcli"
+TCLIG="$PROJECT_DIR/target/debug/tclig"
 
 if [[ ! -x "$TPASS" ]]; then
     echo "ERROR: tpass not found. Run 'cargo build' first."
+    exit 1
+fi
+
+if [[ ! -x "$TCLIG" ]]; then
+    echo "ERROR: tclig not found. Run 'cargo build' first."
     exit 1
 fi
 
@@ -54,11 +60,11 @@ echo "Using key: $KEY_FP"
 TEST_DIR=$(mktemp -d)
 export PASSWORD_STORE_DIR="$TEST_DIR/store"
 
-# Create GPG wrapper so pass uses tcli
+# Create GPG wrapper so pass uses tclig
 WRAPPER_DIR="$TEST_DIR/bin"
 mkdir -p "$WRAPPER_DIR"
-ln -sf "$TCLI" "$WRAPPER_DIR/gpg2"
-ln -sf "$TCLI" "$WRAPPER_DIR/gpg"
+ln -sf "$TCLIG" "$WRAPPER_DIR/gpg2"
+ln -sf "$TCLIG" "$WRAPPER_DIR/gpg"
 export PATH="$WRAPPER_DIR:$PATH"
 
 PASS_COUNT=0


### PR DESCRIPTION
tcli had two audiences: humans (import, list, describe, agent, card status) and programs invoking it as `gpg.program` (git, pass). The 50-flag tcli --help mixed both. Split them:

tcli   -> human-facing key management + SSH agent (~18 flags)
tclig  -> GnuPG drop-in for git, pass, and anything with gpg.program