### PR TITLE
feat(tclig): compatibility fixes for PassFF and browserpass

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ unchanged.
 - **Signature verification** -- verify commits and tags with keys from the tumpa keystore
 - **Encryption / decryption** -- multi-recipient encryption, card-first decryption with software fallback
 - **password-store (`pass`) support** -- works as a drop-in GPG replacement for `pass`
+- **Browser extension support** -- [PassFF](https://github.com/passff/passff) and [Browserpass](https://github.com/browserpass/browserpass-extension) work via the `gpg2 -> tclig` symlink (ciphertext on stdin via `-`, `--debug` flag accepted)
 - **`tpass`** -- native password-store replacement, no GPG dependency
 - **OpenPGP card support** -- cards are tried first for signing, decryption, and SSH auth
 - **Unified agent** -- caches passphrases for GPG operations + optional SSH agent

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -493,6 +493,21 @@ fingerprints), `pass` reencrypts all passwords to the new set of keys.
 `tclig` supports the `--decrypt --list-only` and `--list-keys --with-colons`
 commands that `pass` uses to detect which files need reencryption.
 
+### Browser extensions
+
+Browser extensions that speak to `pass` (via a native messaging host)
+work against the `gpg2 -> tclig` symlink, too:
+
+- **[PassFF](https://github.com/passff/passff)** — invokes gpg with
+  `--debug`. `tclig` accepts and ignores this flag.
+- **[Browserpass](https://github.com/browserpass/browserpass-extension)**
+  — its native host (`browserpass-native`) reads the `.gpg` file
+  itself and pipes the ciphertext to `gpg -d -`. `tclig` treats `-`
+  as stdin, matching gpg's convention.
+
+No configuration beyond the standard `gpg2 -> tclig` symlink is
+needed for either extension.
+
 ---
 
 ## tpass — native password store
@@ -756,6 +771,13 @@ Decrypt to a file:
 
 ```
 tclig -d -o document.txt secret.gpg
+```
+
+Decrypt ciphertext piped on stdin (pass `-` as the input file, same
+convention as `gpg`):
+
+```
+cat secret.gpg | tclig -d -
 ```
 
 `tclig` automatically determines which secret key can decrypt the

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -26,7 +26,7 @@ fn read_ciphertext(input: &Path) -> Result<Vec<u8>> {
 /// it, prompts for the passphrase, and writes plaintext to `output`
 /// (or stdout if None).
 pub fn decrypt(
-    input: &PathBuf,
+    input: &Path,
     output: Option<&PathBuf>,
     keystore_path: Option<&PathBuf>,
 ) -> Result<()> {
@@ -187,7 +187,7 @@ fn try_decrypt_on_card(
 /// Produces output similar to `gpg --decrypt --list-only --keyid-format long`.
 /// Used by `pass` to detect whether reencryption is needed.
 pub fn decrypt_list_only(
-    input: &PathBuf,
+    input: &Path,
     _keystore_path: Option<&PathBuf>,
 ) -> Result<()> {
     let ciphertext = read_ciphertext(input)?;

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -16,7 +16,8 @@ fn read_ciphertext(input: &Path) -> Result<Vec<u8>> {
             .context("Failed to read encrypted data from stdin")?;
         Ok(buf)
     } else {
-        std::fs::read(input).context(format!("Failed to read encrypted file {:?}", input))
+        std::fs::read(input)
+            .with_context(|| format!("Failed to read encrypted file {:?}", input))
     }
 }
 

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -1,11 +1,24 @@
-use std::io::Write;
-use std::path::PathBuf;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use zeroize::Zeroizing;
 
 use crate::pinentry;
 use crate::store;
+
+/// Read ciphertext from a file, or from stdin if `input` is `-`.
+fn read_ciphertext(input: &Path) -> Result<Vec<u8>> {
+    if input.as_os_str() == "-" {
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .context("Failed to read encrypted data from stdin")?;
+        Ok(buf)
+    } else {
+        std::fs::read(input).context(format!("Failed to read encrypted file {:?}", input))
+    }
+}
 
 /// Decrypt a file.
 ///
@@ -19,8 +32,7 @@ pub fn decrypt(
 ) -> Result<()> {
     let keystore = store::open_keystore(keystore_path)?;
 
-    let ciphertext =
-        std::fs::read(input).context(format!("Failed to read encrypted file {:?}", input))?;
+    let ciphertext = read_ciphertext(input)?;
 
     // Find which key IDs this message is encrypted for
     let key_ids = wecanencrypt::bytes_encrypted_for(&ciphertext)
@@ -178,8 +190,7 @@ pub fn decrypt_list_only(
     input: &PathBuf,
     _keystore_path: Option<&PathBuf>,
 ) -> Result<()> {
-    let ciphertext =
-        std::fs::read(input).context(format!("Failed to read encrypted file {:?}", input))?;
+    let ciphertext = read_ciphertext(input)?;
 
     let key_ids = wecanencrypt::bytes_encrypted_for(&ciphertext)
         .context("Failed to inspect encrypted message")?;

--- a/src/tclig/cli.rs
+++ b/src/tclig/cli.rs
@@ -136,6 +136,12 @@ pub struct Args {
     /// GPG --list-config (used by pass to query groups).
     #[clap(long, hide = true)]
     pub list_config: bool,
+
+    #[clap(long, hide = true)]
+    pub debug: Option<String>,
+
+    #[clap(long, hide = true)]
+    pub debug_level: Option<String>,
 }
 
 pub enum Mode {


### PR DESCRIPTION
## Summary
Two small tclig fixes so browser-integrated password-store clients work against the tumpa keystore.

**PassFF** (Firefox extension for password-store) invokes gpg with `--debug`. GPG's `--debug` takes a required argument (flag names like `ipc` or a bitmask); without a matching clap option, tclig rejected it and the whole invocation failed. Added `--debug` and `--debug-level` as hidden compat flags that accept and ignore the value, matching the pattern used for the other GPG-only flags.

**browserpass-native** (host for the Browserpass extension) reads the `.gpg` file itself and pipes it to `gpg -d -`, expecting `-` to mean stdin. tclig was trying to open a file literally named `-` and failing with `Failed to read encrypted file "-"`. `gpg::decrypt` now routes stdin in when the input path is `-`, matching standard gpg behavior; this applies to both `--decrypt` and `--decrypt --list-only`.

## Test plan
- [x] `tclig --debug hej` exits 0 (no unexpected-argument error) — unblocks PassFF
- [x] `cat foo.gpg | tclig -d -` prints plaintext — unblocks browserpass-native
- [x] `cargo build` succeeds
- [x] End-to-end: PassFF fetches a credential through the installed `gpg2 -> tclig` symlink
- [x] End-to-end: Browserpass fetches a credential through the installed `gpg2 -> tclig` symlink