### PR TITLE
fix: show primary UID in --search and --fetch output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,7 +3307,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tumpa-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tumpa-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "OpenPGP operations and SSH agent backed by tumpa keystore."
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ A command-line tool for OpenPGP operations, SSH agent, and
 password management, backed by the
 [tumpa](https://github.com/tumpaproject/tumpa) keystore.
 
+At a glance, tumpa-cli works as a drop-in for:
+
+- **Git** — commit and tag signing + verification via `gpg.program`
+- **pass** — [password-store](https://www.passwordstore.org/) replacement,
+  either through a native `tpass` binary or by pointing `pass` at `tclig`
+- **SSH** — OpenSSH-compatible agent serving keystore keys and OpenPGP
+  card auth subkeys
+- **Browserpass** — [Browserpass](https://github.com/browserpass/browserpass-extension)
+  browser extension via the `gpg2` → `tclig` symlink
+- **PassFF** — [PassFF](https://github.com/passff/passff) Firefox extension,
+  same `gpg2` → `tclig` path
+- **OpenPGP smart cards** — cards are tried first for sign / decrypt / SSH
+  auth, with a software-key fallback from `~/.tumpa/keys.db`
+- **[multiverse/bump-tag](https://github.com/SUNET/multiverse)** — emits
+  the `[GNUPG:]` status lines bump-tag greps for
+
 Three binaries are provided:
 
 - **`tcli`** -- human-facing key management and SSH agent: import, export,

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -514,7 +514,10 @@ pub fn cmd_search(query: &str, email: bool, keystore_path: Option<&PathBuf>) -> 
         let marker = if key.is_secret { "sec" } else { "pub" };
         let uid = key
             .user_ids
-            .first()
+            .iter()
+            .filter(|u| !u.revoked)
+            .max_by_key(|u| u.is_primary)
+            .or_else(|| key.user_ids.first())
             .map(|u| u.value.as_str())
             .unwrap_or("<no UID>");
         println!("{} {} {}", marker, key.fingerprint, uid);


### PR DESCRIPTION
`tcli --search kushaldas` showed "Kushal Das <kushal@fedoraproject.org>" but `tcli --info` for the same key marked "Kushal Das <mail@kushaldas.in>" as [primary]. Same key, same tool, two different headline UIDs - because cmd_search and cmd_fetch grabbed user_ids.first(), i.e. whichever UID was first in serialization order, not the one the owner had marked primary (RFC 9580 Primary User ID subpacket). `--info` / `--desc` already sorted primary first, so the bug was limited to the single-line summary paths.