### PR TITLE
fix(tpass): detect existing git repo in password store

### DIFF
--- a/src/tpass/commands/git.rs
+++ b/src/tpass/commands/git.rs
@@ -5,7 +5,9 @@ use crate::util::{config, git};
 /// `tpass git git-command-args...`
 pub fn cmd_git(args: &[String]) -> Result<()> {
     let prefix = config::store_dir();
-    let git_dir = git::find_git_dir(&prefix.join("."), &prefix);
+    // Pass a real child name, not ".": Path::parent() skips CurDir components,
+    // so prefix.join(".").parent() would jump above prefix and miss the repo.
+    let git_dir = git::find_git_dir(&prefix.join(".gpg-id"), &prefix);
 
     if args.first().map(|s| s.as_str()) == Some("init") {
         // Special case: git init

--- a/tests/test_tpass.sh
+++ b/tests/test_tpass.sh
@@ -334,6 +334,12 @@ else
     FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
+# Regression: non-init git subcommands must detect the existing repo.
+# Pre-fix, find_git_dir was invoked with prefix.join(".") and Path::parent()
+# skipped the CurDir component, so tpass misreported the store as non-git.
+pass_test "git status on existing repo" "$TPASS" git status
+pass_test "git log on existing repo" "$TPASS" git log --oneline
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary
- `tpass git <cmd>` always failed with `Error: the password store is not a git repository. Try "tpass git init".` even when the store had a valid `.git` dir.
- Root cause: `src/tpass/commands/git.rs` called `find_git_dir(&prefix.join("."), &prefix)`. Rust's `Path::parent()` skips `CurDir` components, so `prefix.join(".").parent()` resolves to the *grandparent* of the store, failing the `starts_with(prefix)` guard and breaking out of the walk-up loop before git is ever consulted.
- Fix: pass `prefix.join(".gpg-id")` — a real child whose `.parent()` reliably returns the store root. No other `find_git_dir` call sites are affected; they all pass real file paths.

## Test plan
- [x] Reproduced `Error: the password store is not a git repository.` with `tpass 0.3.1` against an existing pass store with `.git`.
- [x] `cargo build --release --bin tpass` succeeds.
- [x] `tpass git status` on the same store now returns the repo's status (exit 0).
- [ ] Verify `tpass git init` still works on a fresh store (special-cased path, unchanged).
- [x] Verify `tpass git log`, `tpass git pull`, `tpass git push` forward correctly.