### PR TITLE
fix: no bad pin cache

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,8 +30,12 @@ test-pass: build
 test-keystore: build
     ./tests/test_keystore.sh
 
+# Regression test for issue #19: agent must not cache a wrong passphrase
+test-agent-cache: build
+    TUMPA_PASSPHRASE="${TUMPA_PASSPHRASE}" ./tests/test_agent_no_bad_cache.sh
+
 # Run all test suites
-test-all: test test-compat test-pass test-keystore
+test-all: test test-compat test-pass test-keystore test-agent-cache
 
 # Build, lint, and test
 check: build lint test

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -154,11 +154,12 @@ fn decrypt_with_software(
             .map(|u| u.value.as_str())
             .unwrap_or(&key_info.fingerprint)
     );
-    let passphrase =
+    // `Passphrase` is `Zeroizing<String>`; pass the value libtumpa
+    // expects directly without a plaintext `to_string()` copy.
+    let passphrase: Passphrase =
         pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))?;
-    let pass = Passphrase::new(passphrase.to_string());
 
-    match ltd::decrypt_with_key(&key_data, ciphertext, &pass) {
+    match ltd::decrypt_with_key(&key_data, ciphertext, &passphrase) {
         Ok(z) => {
             pinentry::cache_passphrase(&key_info.fingerprint, &passphrase);
             Ok(Zeroizing::new(z.to_vec()))

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -116,10 +116,16 @@ fn try_decrypt_on_card(
     let pin = pinentry::get_passphrase(&desc, "PIN", Some(&card.key_info.fingerprint))?;
     let pin_obj = Pin::new(pin.as_bytes().to_vec());
 
-    ltd::decrypt_on_card(&card.key_data, ciphertext, &pin_obj)
-        .map(|z| Zeroizing::new(z.to_vec()))
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .context("Card decryption failed")
+    match ltd::decrypt_on_card(&card.key_data, ciphertext, &pin_obj) {
+        Ok(z) => {
+            pinentry::cache_passphrase(&card.key_info.fingerprint, &pin);
+            Ok(Zeroizing::new(z.to_vec()))
+        }
+        Err(e) => {
+            pinentry::clear_cached_passphrase(&card.key_info.fingerprint);
+            Err(anyhow::anyhow!("{e}")).context("Card decryption failed")
+        }
+    }
 }
 
 /// Software fallback: find a secret key in the keystore for one of the
@@ -152,10 +158,16 @@ fn decrypt_with_software(
         pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))?;
     let pass = Passphrase::new(passphrase.to_string());
 
-    ltd::decrypt_with_key(&key_data, ciphertext, &pass)
-        .map(|z| Zeroizing::new(z.to_vec()))
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .context("Decryption failed")
+    match ltd::decrypt_with_key(&key_data, ciphertext, &pass) {
+        Ok(z) => {
+            pinentry::cache_passphrase(&key_info.fingerprint, &passphrase);
+            Ok(Zeroizing::new(z.to_vec()))
+        }
+        Err(e) => {
+            pinentry::clear_cached_passphrase(&key_info.fingerprint);
+            Err(anyhow::anyhow!("{e}")).context("Decryption failed")
+        }
+    }
 }
 
 /// Inspect an encrypted file and print which key IDs it is encrypted for.

--- a/src/gpg/sign.rs
+++ b/src/gpg/sign.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Context, Result};
+use zeroize::Zeroizing;
 
 use libtumpa::sign::{
     sign_detached as libtumpa_sign_detached, Secret, SecretRequest, SignBackend,
@@ -44,6 +45,13 @@ pub fn sign(
     // `tcli: Signed with card <ident> ...` message after libtumpa returns.
     let card_ident_used: RefCell<Option<String>> = RefCell::new(None);
 
+    // Capture the secret value produced by the latest closure call so
+    // we can write it into the agent cache only after libtumpa
+    // confirms the sign succeeded. libtumpa may call the closure twice
+    // (CardPin then KeyPassphrase fallback); the final value is the
+    // one that actually drove the successful op.
+    let last_secret: RefCell<Option<Zeroizing<String>>> = RefCell::new(None);
+
     let result = libtumpa_sign_detached(&key_data, &key_info, &buffer, |req| match req {
         SecretRequest::CardPin {
             card_ident,
@@ -52,16 +60,29 @@ pub fn sign(
             *card_ident_used.borrow_mut() = Some(card_ident.to_string());
             let pin = prompt_card_pin(card_ident, key_info)
                 .map_err(|e| libtumpa::Error::Sign(format!("pinentry: {e}")))?;
+            *last_secret.borrow_mut() = Some(Zeroizing::new(pin.clone()));
             Ok(Secret::Pin(Pin::new(pin.into_bytes())))
         }
         SecretRequest::KeyPassphrase { key_info } => {
             let pass = prompt_key_passphrase(key_info)
                 .map_err(|e| libtumpa::Error::Sign(format!("pinentry: {e}")))?;
+            *last_secret.borrow_mut() = Some(Zeroizing::new(pass.clone()));
             Ok(Secret::Passphrase(Passphrase::new(pass)))
         }
     });
 
-    let (signature, backend) = result.map_err(|e| anyhow!("{e}"))?;
+    let (signature, backend) = match result {
+        Ok(ok) => {
+            if let Some(secret) = last_secret.borrow().as_ref() {
+                pinentry::cache_passphrase(&key_info.fingerprint, secret);
+            }
+            ok
+        }
+        Err(e) => {
+            pinentry::clear_cached_passphrase(&key_info.fingerprint);
+            return Err(anyhow!("{e}"));
+        }
+    };
 
     match backend {
         SignBackend::Card => {

--- a/src/gpg/sign.rs
+++ b/src/gpg/sign.rs
@@ -49,7 +49,9 @@ pub fn sign(
     // we can write it into the agent cache only after libtumpa
     // confirms the sign succeeded. libtumpa may call the closure twice
     // (CardPin then KeyPassphrase fallback); the final value is the
-    // one that actually drove the successful op.
+    // one that actually drove the successful op. The secret stays in
+    // `Zeroizing<String>` end-to-end so transient copies are wiped on
+    // drop.
     let last_secret: RefCell<Option<Zeroizing<String>>> = RefCell::new(None);
 
     let result = libtumpa_sign_detached(&key_data, &key_info, &buffer, |req| match req {
@@ -58,16 +60,22 @@ pub fn sign(
             key_info,
         } => {
             *card_ident_used.borrow_mut() = Some(card_ident.to_string());
-            let pin = prompt_card_pin(card_ident, key_info)
+            let pin: Zeroizing<String> = prompt_card_pin(card_ident, key_info)
                 .map_err(|e| libtumpa::Error::Sign(format!("pinentry: {e}")))?;
-            *last_secret.borrow_mut() = Some(Zeroizing::new(pin.clone()));
-            Ok(Secret::Pin(Pin::new(pin.into_bytes())))
+            // Pin is `Zeroizing<Vec<u8>>`; the source bytes get copied
+            // into a zeroizing Vec, then `pin` (the `Zeroizing<String>`)
+            // moves into `last_secret`.
+            let pin_bytes: Pin = Zeroizing::new(pin.as_bytes().to_vec());
+            *last_secret.borrow_mut() = Some(pin);
+            Ok(Secret::Pin(pin_bytes))
         }
         SecretRequest::KeyPassphrase { key_info } => {
-            let pass = prompt_key_passphrase(key_info)
+            let pass: Passphrase = prompt_key_passphrase(key_info)
                 .map_err(|e| libtumpa::Error::Sign(format!("pinentry: {e}")))?;
-            *last_secret.borrow_mut() = Some(Zeroizing::new(pass.clone()));
-            Ok(Secret::Passphrase(Passphrase::new(pass)))
+            // `Passphrase` is `Zeroizing<String>`; cloning produces
+            // another zeroizing copy (no plaintext leak).
+            *last_secret.borrow_mut() = Some(pass.clone());
+            Ok(Secret::Passphrase(pass))
         }
     });
 
@@ -118,7 +126,13 @@ pub fn sign(
 
 /// Prompt the user for the card PIN via pinentry, including card-status
 /// context (cardholder, signature counter) when available.
-fn prompt_card_pin(card_ident: &str, key_info: &wecanencrypt::KeyInfo) -> Result<String> {
+///
+/// Returns `Zeroizing<String>` so the secret is wiped from memory when
+/// the value is dropped — never converted to a plain `String`.
+fn prompt_card_pin(
+    card_ident: &str,
+    key_info: &wecanencrypt::KeyInfo,
+) -> Result<Zeroizing<String>> {
     let card_info = wecanencrypt::card::get_card_details(Some(card_ident)).ok();
     let uid = primary_uid(key_info);
 
@@ -137,15 +151,16 @@ fn prompt_card_pin(card_ident: &str, key_info: &wecanencrypt::KeyInfo) -> Result
     }
     desc.push_str(&format!("\n\nSigning as: {}", uid));
 
-    let pin = pinentry::get_passphrase(&desc, "PIN", Some(&key_info.fingerprint))?;
-    Ok(pin.to_string())
+    pinentry::get_passphrase(&desc, "PIN", Some(&key_info.fingerprint))
 }
 
 /// Prompt the user for the secret-key passphrase via pinentry.
-fn prompt_key_passphrase(key_info: &wecanencrypt::KeyInfo) -> Result<String> {
+///
+/// Returns `Zeroizing<String>` so the secret is wiped from memory when
+/// the value is dropped — never converted to a plain `String`.
+fn prompt_key_passphrase(key_info: &wecanencrypt::KeyInfo) -> Result<Zeroizing<String>> {
     let desc = format!("Enter passphrase for key {}", primary_uid(key_info));
-    let pass = pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))?;
-    Ok(pass.to_string())
+    pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))
 }
 
 /// Get the primary UID string from a certificate, falling back to the first

--- a/src/pinentry.rs
+++ b/src/pinentry.rs
@@ -11,10 +11,13 @@ use crate::agent;
 /// Get a passphrase or PIN via the pinentry program.
 ///
 /// Acquisition order:
-/// 1. Agent cache (if tcli agent is running and `cache_key` is `Some`)
-/// 2. TUMPA_PASSPHRASE env var
-/// 3. pinentry program
-/// 4. Terminal prompt
+/// 1. Agent cache (if tcli agent is running, `cache_key` is `Some`, and
+///    `prompt` is not `"Admin PIN"`)
+/// 2. `TUMPA_ADMIN_PIN` env var — only when `prompt` is `"Admin PIN"`
+///    (case-insensitive); skipped for any other prompt.
+/// 3. `TUMPA_PASSPHRASE` env var
+/// 4. pinentry program
+/// 5. Terminal prompt
 ///
 /// `cache_key` is the key fingerprint used for **reading** the agent
 /// cache. A returned value is **never written** to the cache by this
@@ -27,11 +30,16 @@ pub fn get_passphrase(
     prompt: &str,
     cache_key: Option<&str>,
 ) -> Result<Zeroizing<String>> {
-    // 1. Check agent cache
-    if let Some(key) = cache_key {
-        if let Some(pass) = try_agent_get(key) {
-            log::debug!("Using passphrase from agent cache");
-            return Ok(pass);
+    let allow_agent_cache = should_use_agent_cache(prompt);
+
+    // 1. Check agent cache for user PIN/passphrase prompts only.
+    // Admin PIN must not share the generic fingerprint cache key.
+    if allow_agent_cache {
+        if let Some(key) = cache_key {
+            if let Some(pass) = try_agent_get(key) {
+                log::debug!("Using passphrase from agent cache");
+                return Ok(pass);
+            }
         }
     }
 
@@ -62,6 +70,10 @@ pub fn get_passphrase(
 
     // 4. Fall back to terminal prompt
     rpassword_prompt(prompt)
+}
+
+fn should_use_agent_cache(prompt: &str) -> bool {
+    !prompt.eq_ignore_ascii_case("Admin PIN")
 }
 
 /// Store a passphrase / PIN in the running tumpa agent's cache.
@@ -113,7 +125,12 @@ fn try_agent_put(fingerprint: &str, passphrase: &Zeroizing<String>) {
         Err(_) => return,
     };
 
-    let mut stream = match UnixStream::connect(&socket_path) {
+    try_agent_put_at_path(&socket_path, fingerprint, passphrase);
+}
+
+fn try_agent_put_at_path(socket_path: &Path, fingerprint: &str, passphrase: &Zeroizing<String>) {
+
+    let mut stream = match UnixStream::connect(socket_path) {
         Ok(s) => s,
         Err(_) => return,
     };
@@ -143,7 +160,12 @@ fn try_agent_clear(fingerprint: &str) {
         Err(_) => return,
     };
 
-    let mut stream = match UnixStream::connect(&socket_path) {
+    try_agent_clear_at_path(&socket_path, fingerprint);
+}
+
+fn try_agent_clear_at_path(socket_path: &Path, fingerprint: &str) {
+
+    let mut stream = match UnixStream::connect(socket_path) {
         Ok(s) => s,
         Err(_) => return,
     };
@@ -441,35 +463,39 @@ mod cache_helper_tests {
     //! When no agent is listening on `~/.tumpa/agent.sock`, the helpers
     //! must silently no-op rather than panic or block. This is the
     //! contract callers in gpg/sign and gpg/decrypt rely on.
-    use super::{cache_passphrase, clear_cached_passphrase};
+    use super::{try_agent_clear_at_path, try_agent_put_at_path};
+    use std::path::Path;
     use zeroize::Zeroizing;
 
-    /// Point HOME at a guaranteed non-existent path so
-    /// `default_socket_path()` resolves to a socket that can't be
-    /// reached. Both helpers must return without error.
-    ///
-    /// This `set_var` is process-wide; gating the assertions to only
-    /// these two tests in this module keeps the blast radius small,
-    /// and the tests don't depend on the original HOME value.
-    fn point_home_at_nothing() {
-        unsafe {
-            std::env::set_var(
-                "HOME",
-                "/tmp/tumpa-cli-pinentry-test-no-such-dir-xyz",
-            );
-        }
+    fn unreachable_socket_path() -> &'static Path {
+        Path::new("/proc/tumpa-cli-pinentry-tests/no-such-socket.sock")
     }
 
     #[test]
     fn cache_passphrase_no_agent_is_silent() {
-        point_home_at_nothing();
         let pass = Zeroizing::new("ignored".to_string());
-        cache_passphrase("AAAAAAAAAAAAAAAA", &pass);
+        try_agent_put_at_path(unreachable_socket_path(), "AAAAAAAAAAAAAAAA", &pass);
     }
 
     #[test]
     fn clear_cached_passphrase_no_agent_is_silent() {
-        point_home_at_nothing();
-        clear_cached_passphrase("AAAAAAAAAAAAAAAA");
+        try_agent_clear_at_path(unreachable_socket_path(), "AAAAAAAAAAAAAAAA");
+    }
+}
+
+#[cfg(test)]
+mod get_passphrase_policy_tests {
+    use super::should_use_agent_cache;
+
+    #[test]
+    fn admin_pin_skips_agent_cache() {
+        assert!(!should_use_agent_cache("Admin PIN"));
+        assert!(!should_use_agent_cache("admin pin"));
+    }
+
+    #[test]
+    fn user_pin_and_passphrase_still_use_agent_cache() {
+        assert!(should_use_agent_cache("PIN"));
+        assert!(should_use_agent_cache("Passphrase"));
     }
 }

--- a/src/pinentry.rs
+++ b/src/pinentry.rs
@@ -11,16 +11,17 @@ use crate::agent;
 /// Get a passphrase or PIN via the pinentry program.
 ///
 /// Acquisition order:
-/// 1. Agent cache (if tcli agent is running)
+/// 1. Agent cache (if tcli agent is running and `cache_key` is `Some`)
 /// 2. TUMPA_PASSPHRASE env var
 /// 3. pinentry program
 /// 4. Terminal prompt
 ///
-/// If a passphrase is obtained from steps 2-4 and the agent is running,
-/// it is stored in the agent cache for future use.
-///
-/// `cache_key` is the key fingerprint used for agent cache lookups.
-/// If None, agent caching is skipped.
+/// `cache_key` is the key fingerprint used for **reading** the agent
+/// cache. A returned value is **never written** to the cache by this
+/// function — the caller must call [`cache_passphrase`] after a
+/// successful sign/decrypt and [`clear_cached_passphrase`] after a
+/// failed one. Caching unverified values would burn card PIN attempts
+/// when the user typed the wrong PIN once.
 pub fn get_passphrase(
     description: &str,
     prompt: &str,
@@ -48,32 +49,36 @@ pub fn get_passphrase(
     // passphrases and user PINs.
     if let Ok(pass) = std::env::var("TUMPA_PASSPHRASE") {
         log::debug!("Using passphrase from TUMPA_PASSPHRASE env var");
-        let pass = Zeroizing::new(pass);
-        if let Some(key) = cache_key {
-            try_agent_put(key, &pass);
-        }
-        return Ok(pass);
+        return Ok(Zeroizing::new(pass));
     }
 
     // 3. Try pinentry
     match try_pinentry(description, prompt) {
-        Ok(pass) => {
-            if let Some(key) = cache_key {
-                try_agent_put(key, &pass);
-            }
-            return Ok(pass);
-        }
+        Ok(pass) => return Ok(pass),
         Err(e) => {
             log::debug!("pinentry failed: {}, falling back to terminal", e);
         }
     }
 
     // 4. Fall back to terminal prompt
-    let pass = rpassword_prompt(prompt)?;
-    if let Some(key) = cache_key {
-        try_agent_put(key, &pass);
-    }
-    Ok(pass)
+    rpassword_prompt(prompt)
+}
+
+/// Store a passphrase / PIN in the running tumpa agent's cache.
+///
+/// Call this only **after** the value has been confirmed correct by a
+/// successful sign or decrypt. Silent no-op if no agent is running.
+pub fn cache_passphrase(fingerprint: &str, passphrase: &Zeroizing<String>) {
+    try_agent_put(fingerprint, passphrase);
+}
+
+/// Drop a cached passphrase / PIN from the running tumpa agent.
+///
+/// Call this whenever a sign or decrypt operation fails, to ensure a
+/// stale (or freshly-typed-but-wrong) value is never reused on the
+/// next request. Silent no-op if no agent is running.
+pub fn clear_cached_passphrase(fingerprint: &str) {
+    try_agent_clear(fingerprint);
 }
 
 /// Try to get a cached passphrase from the agent.
@@ -122,6 +127,32 @@ fn try_agent_put(fingerprint: &str, passphrase: &Zeroizing<String>) {
         base64::engine::general_purpose::STANDARD.encode(passphrase.as_bytes())
     };
     let request = format!("PUT_PASSPHRASE {} {}\n", fingerprint, b64);
+    let _ = stream.write_all(request.as_bytes());
+
+    // Read the OK response
+    let mut response = String::new();
+    let mut reader = std::io::BufReader::new(&stream);
+    let _ = reader.read_line(&mut response);
+}
+
+/// Try to drop a cached passphrase from the agent.
+/// Silently does nothing if agent is not running.
+fn try_agent_clear(fingerprint: &str) {
+    let socket_path = match agent::default_socket_path() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let mut stream = match UnixStream::connect(&socket_path) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+        .ok();
+
+    let request = format!("CLEAR_PASSPHRASE {}\n", fingerprint);
     let _ = stream.write_all(request.as_bytes());
 
     // Read the OK response
@@ -400,5 +431,45 @@ mod cardholder_tests {
     #[test]
     fn single_given_name_no_surname_with_spaces() {
         assert_eq!(format_cardholder_name("<<Kushal<Das"), "Kushal Das");
+    }
+}
+
+#[cfg(test)]
+mod cache_helper_tests {
+    //! Coverage for the agent cache helpers in their no-agent branch.
+    //!
+    //! When no agent is listening on `~/.tumpa/agent.sock`, the helpers
+    //! must silently no-op rather than panic or block. This is the
+    //! contract callers in gpg/sign and gpg/decrypt rely on.
+    use super::{cache_passphrase, clear_cached_passphrase};
+    use zeroize::Zeroizing;
+
+    /// Point HOME at a guaranteed non-existent path so
+    /// `default_socket_path()` resolves to a socket that can't be
+    /// reached. Both helpers must return without error.
+    ///
+    /// This `set_var` is process-wide; gating the assertions to only
+    /// these two tests in this module keeps the blast radius small,
+    /// and the tests don't depend on the original HOME value.
+    fn point_home_at_nothing() {
+        unsafe {
+            std::env::set_var(
+                "HOME",
+                "/tmp/tumpa-cli-pinentry-test-no-such-dir-xyz",
+            );
+        }
+    }
+
+    #[test]
+    fn cache_passphrase_no_agent_is_silent() {
+        point_home_at_nothing();
+        let pass = Zeroizing::new("ignored".to_string());
+        cache_passphrase("AAAAAAAAAAAAAAAA", &pass);
+    }
+
+    #[test]
+    fn clear_cached_passphrase_no_agent_is_silent() {
+        point_home_at_nothing();
+        clear_cached_passphrase("AAAAAAAAAAAAAAAA");
     }
 }

--- a/src/tpass/util/crypto.rs
+++ b/src/tpass/util/crypto.rs
@@ -130,11 +130,12 @@ fn decrypt_with_software(
             .map(|u| u.value.as_str())
             .unwrap_or(&key_info.fingerprint)
     );
-    let passphrase =
+    // `Passphrase` is `Zeroizing<String>`; pass the value libtumpa
+    // expects directly without a plaintext `to_string()` copy.
+    let passphrase: Passphrase =
         pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))?;
-    let pass = Passphrase::new(passphrase.to_string());
 
-    match ltd::decrypt_with_key(&key_data, ciphertext, &pass) {
+    match ltd::decrypt_with_key(&key_data, ciphertext, &passphrase) {
         Ok(z) => {
             pinentry::cache_passphrase(&key_info.fingerprint, &passphrase);
             Ok(Zeroizing::new(z.to_vec()))
@@ -219,20 +220,22 @@ pub fn sign_file_detached(
                 .map(|u| u.value.as_str())
                 .unwrap_or(&key_info.fingerprint)
         );
-        let passphrase =
+        // `Passphrase` is `Zeroizing<String>`; pass it directly to
+        // libtumpa to avoid an extra plaintext `to_string()` copy.
+        let passphrase: Passphrase =
             pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))?;
-        let pass = Passphrase::new(passphrase.to_string());
 
-        let signature = match libtumpa::sign::sign_detached_with_key(&key_data, &data, &pass) {
-            Ok(sig) => {
-                pinentry::cache_passphrase(&key_info.fingerprint, &passphrase);
-                sig
-            }
-            Err(e) => {
-                pinentry::clear_cached_passphrase(&key_info.fingerprint);
-                return Err(anyhow::anyhow!("{e}")).context("Signing failed");
-            }
-        };
+        let signature =
+            match libtumpa::sign::sign_detached_with_key(&key_data, &data, &passphrase) {
+                Ok(sig) => {
+                    pinentry::cache_passphrase(&key_info.fingerprint, &passphrase);
+                    sig
+                }
+                Err(e) => {
+                    pinentry::clear_cached_passphrase(&key_info.fingerprint);
+                    return Err(anyhow::anyhow!("{e}")).context("Signing failed");
+                }
+            };
 
         std::fs::write(&sig_file, signature.as_bytes())
             .context(format!("Failed to write signature file {:?}", sig_file))?;

--- a/src/tpass/util/crypto.rs
+++ b/src/tpass/util/crypto.rs
@@ -93,10 +93,16 @@ fn try_decrypt_on_card(
     let pin = pinentry::get_passphrase(&desc, "PIN", Some(&card.key_info.fingerprint))?;
     let pin_obj = Pin::new(pin.as_bytes().to_vec());
 
-    ltd::decrypt_on_card(&card.key_data, ciphertext, &pin_obj)
-        .map(|z| Zeroizing::new(z.to_vec()))
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .context("Card decryption failed")
+    match ltd::decrypt_on_card(&card.key_data, ciphertext, &pin_obj) {
+        Ok(z) => {
+            pinentry::cache_passphrase(&card.key_info.fingerprint, &pin);
+            Ok(Zeroizing::new(z.to_vec()))
+        }
+        Err(e) => {
+            pinentry::clear_cached_passphrase(&card.key_info.fingerprint);
+            Err(anyhow::anyhow!("{e}")).context("Card decryption failed")
+        }
+    }
 }
 
 /// Software-side decrypt using libtumpa primitives, with pinentry here.
@@ -128,10 +134,16 @@ fn decrypt_with_software(
         pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))?;
     let pass = Passphrase::new(passphrase.to_string());
 
-    ltd::decrypt_with_key(&key_data, ciphertext, &pass)
-        .map(|z| Zeroizing::new(z.to_vec()))
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .context("Decryption failed")
+    match ltd::decrypt_with_key(&key_data, ciphertext, &pass) {
+        Ok(z) => {
+            pinentry::cache_passphrase(&key_info.fingerprint, &passphrase);
+            Ok(Zeroizing::new(z.to_vec()))
+        }
+        Err(e) => {
+            pinentry::clear_cached_passphrase(&key_info.fingerprint);
+            Err(anyhow::anyhow!("{e}")).context("Decryption failed")
+        }
+    }
 }
 
 /// Get key IDs a file is encrypted to (for reencrypt comparison).
@@ -211,9 +223,16 @@ pub fn sign_file_detached(
             pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))?;
         let pass = Passphrase::new(passphrase.to_string());
 
-        let signature = libtumpa::sign::sign_detached_with_key(&key_data, &data, &pass)
-            .map_err(|e| anyhow::anyhow!("{e}"))
-            .context("Signing failed")?;
+        let signature = match libtumpa::sign::sign_detached_with_key(&key_data, &data, &pass) {
+            Ok(sig) => {
+                pinentry::cache_passphrase(&key_info.fingerprint, &passphrase);
+                sig
+            }
+            Err(e) => {
+                pinentry::clear_cached_passphrase(&key_info.fingerprint);
+                return Err(anyhow::anyhow!("{e}")).context("Signing failed");
+            }
+        };
 
         std::fs::write(&sig_file, signature.as_bytes())
             .context(format!("Failed to write signature file {:?}", sig_file))?;

--- a/tests/test_agent_no_bad_cache.sh
+++ b/tests/test_agent_no_bad_cache.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Regression test for tumpa-cli issue #19:
+# https://github.com/tumpaproject/tumpa-cli/issues/19
+#
+# The unified agent must NOT cache a PIN / passphrase that turned out to
+# be wrong. Pre-fix, get_passphrase eagerly cached every value it
+# produced from TUMPA_PASSPHRASE / pinentry / terminal, *before*
+# verifying it via sign / decrypt. A single typo would then poison the
+# cache and either silently fail every subsequent op (software keys) or
+# burn through a card's three PIN attempts.
+#
+# This script exercises that path with software-key signing using
+# TUMPA_PASSPHRASE as a non-interactive driver.
+#
+# Usage:
+#   TUMPA_PASSPHRASE="<correct>" ./tests/test_agent_no_bad_cache.sh [FINGERPRINT]
+
+set -euo pipefail
+
+# --- Locate binaries ---
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TCLI="$PROJECT_DIR/target/debug/tcli"
+TCLIG="$PROJECT_DIR/target/debug/tclig"
+
+if [[ ! -x "$TCLI" || ! -x "$TCLIG" ]]; then
+    echo "ERROR: tcli/tclig not built. Run 'cargo build' first."
+    exit 1
+fi
+
+if [[ -z "${TUMPA_PASSPHRASE:-}" ]]; then
+    echo "ERROR: TUMPA_PASSPHRASE must hold the correct passphrase."
+    exit 1
+fi
+
+CORRECT_PASS="$TUMPA_PASSPHRASE"
+WRONG_PASS="definitely-not-the-passphrase-${RANDOM}-${RANDOM}"
+
+# --- Pick a signing key ---
+
+if [[ -n "${1:-}" ]]; then
+    KEY_FP="$1"
+else
+    KEY_FP=$("$TCLI" --list-keys 2>/dev/null \
+        | grep "^sec" | head -1 | awk '{print $2}' || true)
+fi
+if [[ -z "$KEY_FP" ]]; then
+    echo "ERROR: No secret key found in tumpa keystore."
+    exit 1
+fi
+echo "Using key: $KEY_FP"
+
+# --- Hermetic HOME so the real user agent isn't touched ---
+
+ORIG_HOME="${HOME}"
+ORIG_KEYSTORE="${TUMPA_KEYSTORE:-$ORIG_HOME/.tumpa/keys.db}"
+TEST_HOME=$(mktemp -d)
+mkdir -p "$TEST_HOME/.tumpa"
+export HOME="$TEST_HOME"
+export TUMPA_KEYSTORE="$ORIG_KEYSTORE"
+
+AGENT_PID=""
+DATA_FILE=$(mktemp)
+echo "regression test for issue #19" > "$DATA_FILE"
+
+cleanup() {
+    if [[ -n "$AGENT_PID" ]] && kill -0 "$AGENT_PID" 2>/dev/null; then
+        kill "$AGENT_PID" 2>/dev/null || true
+        wait "$AGENT_PID" 2>/dev/null || true
+    fi
+    rm -f "$DATA_FILE"
+    rm -rf "$TEST_HOME"
+}
+trap cleanup EXIT
+
+# --- Start the agent in our hermetic HOME ---
+
+# Strip TUMPA_PASSPHRASE from the agent's own env: the agent doesn't
+# consult it, but leaving it set would obscure intent.
+env -u TUMPA_PASSPHRASE "$TCLI" agent >/dev/null 2>&1 &
+AGENT_PID=$!
+
+SOCKET="$HOME/.tumpa/agent.sock"
+for _ in $(seq 1 50); do
+    if [[ -S "$SOCKET" ]]; then
+        break
+    fi
+    sleep 0.1
+done
+if [[ ! -S "$SOCKET" ]]; then
+    echo "ERROR: agent did not bind $SOCKET within 5s."
+    exit 1
+fi
+
+# --- Test helpers ---
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_pass() {
+    local name="$1"; shift
+    echo -n "  $name ... "
+    if "$@"; then
+        echo "OK"; PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "FAIL"; FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+assert_fail() {
+    local name="$1"; shift
+    echo -n "  $name ... "
+    if ! "$@"; then
+        echo "OK"; PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "FAIL (expected non-zero exit)"; FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+sign_with() {
+    local pass_env=("$@")
+    "${pass_env[@]}" "$TCLIG" -bsau "$KEY_FP" \
+        < "$DATA_FILE" > /dev/null 2>&1
+}
+
+run_sign_wrong()   { sign_with env "TUMPA_PASSPHRASE=$WRONG_PASS";   }
+run_sign_correct() { sign_with env "TUMPA_PASSPHRASE=$CORRECT_PASS"; }
+run_sign_no_env()  { sign_with env -u TUMPA_PASSPHRASE;              }
+
+# --- Tests ---
+
+echo ""
+echo "=== Issue #19: agent must not cache wrong passphrase ==="
+echo ""
+
+# 1. A wrong passphrase must fail signing.
+assert_fail "[1] sign with wrong passphrase fails" run_sign_wrong
+
+# 2. Immediately after, the correct passphrase must succeed.
+#    Pre-fix, step 1 cached the wrong value under the fingerprint and
+#    get_passphrase preferred cache over env → this would also fail.
+assert_pass "[2] sign with correct passphrase succeeds" run_sign_correct
+
+# 3. With TUMPA_PASSPHRASE unset, signing must still succeed because
+#    the correct value from step 2 is now cached. Guards against an
+#    over-zealous fix that also disables caching of good values.
+assert_pass "[3] re-sign uses cached good passphrase" run_sign_no_env
+
+# --- Summary ---
+
+echo ""
+echo "=== Results: $PASS_COUNT passed, $FAIL_COUNT failed ==="
+exit "$FAIL_COUNT"


### PR DESCRIPTION
Fixes #19 get_passphrase() used to write every value it produced into the agent cache before sign/decrypt could verify it. A single typo poisoned the cache: software keys silently failed every retry, and OpenPGP cards burned through their 3-attempt limit.

Caching is now caller-driven. get_passphrase() only reads the cache; callers in gpg/sign, gpg/decrypt, and tpass/util/crypto write on Ok and clear on Err via new cache_passphrase / clear_cached_passphrase helpers. SSH agent paths already used this discipline.