### PR TITLE
fix: namespace cached PINs and passphrases, wire sign/verify tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "libtumpa"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d081395654e2a1f898d460f7b8a3356f5d09d40dde5415477993b95220a57f1"
+checksum = "65c057db24f7db05fd6b1efb0d3474ede4bc55917241dab68ea519fd9627cd0c"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ experimental = []
 # 0.14.1 ships the Curve25519 `0x40` prefix + (X25519, X25519) match
 # arm needed by Nitrokey 3 (opcard-rs >= 1.5) ECC card uploads.
 wecanencrypt = { version = "0.14.1", features = ["keystore", "card-pcsc", "network"] }
-libtumpa = { version = "0.2.2", features = ["card", "network"] }
+libtumpa = { version = "0.2.3", features = ["card", "network"] }
 # Must match wecanencrypt's pgp dependency exactly -- both crates parse
 # detached signatures using pgp::composed::DetachedSignature, and a version
 # mismatch could cause parser disagreement (see verify.rs dual-parse note).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ At a glance, tumpa-cli works as a drop-in for:
 Three binaries are provided:
 
 - **`tcli`** -- human-facing key management and SSH agent: import, export,
-  search, fetch, describe, list, delete, card status, agent daemons
+  search, fetch, describe, list, delete, card status, agent daemons, sign and verification.
 - **`tclig`** -- GnuPG drop-in for programs that invoke `gpg` (git signing,
   `pass`, anything with a `gpg.program` hook)
 - **`tpass`** -- drop-in replacement for [password-store](https://www.passwordstore.org/)
@@ -35,24 +35,6 @@ stored in `~/.tumpa/keys.db`.
 For detailed usage instructions, see the
 [Usage Guide](https://github.com/tumpaproject/tumpa-cli/blob/main/docs/usage.md).
 
-## Upgrading from 0.1.x
-
-As of 0.3.0, the GPG drop-in flags (`-bsau`, `--verify`, `-e`, `-d`,
-`--list-keys --with-colons`, `--decrypt --list-only`, etc.) have
-moved out of `tcli` into a new binary **`tclig`**. `tcli` is now the
-human-facing key-management UI only.
-
-If you configured git with `gpg.program = tcli`, or symlinked
-`gpg2` to `tcli`, re-point them at `tclig`:
-
-```
-git config --global gpg.program tclig
-ln -sf $(which tclig) ~/bin/gpg2
-```
-
-Everything you typed at the `tcli` prompt as a human (`tcli
---import`, `tcli --list-keys`, `tcli agent --ssh`, etc.) is
-unchanged.
 
 ## Features
 
@@ -307,6 +289,40 @@ tumpa keystore.
 
 Git invokes `tclig --verify <sigfile> -` automatically for commands
 like `git verify-commit`, `git verify-tag`, and `git log --show-signature`.
+
+### Signing and verifying files with `tcli`
+
+For ad-hoc signing of arbitrary files at the shell, `tcli` exposes
+three human-friendly commands. Pick a key by fingerprint, key ID, or
+**email**:
+
+```
+# Detached signature (default = ASCII armored, sibling .asc).
+tcli --sign report.pdf --with-key alice@example.com
+# -> writes report.pdf.asc
+
+# Binary detached (.sig instead of .asc).
+tcli --sign report.pdf --with-key alice@example.com --binary
+
+# Inline cleartext (-----BEGIN PGP SIGNED MESSAGE-----, software keys only).
+tcli --sign-inline notice.txt --with-key alice@example.com
+
+# Verify a detached signature against the keystore.
+tcli --verify report.pdf --signature report.pdf.asc
+
+# Verify a cleartext-signed message in place.
+tcli --verify notice.txt.asc
+
+# Verify against an external public-key file (skips the keystore).
+tcli --verify report.pdf --signature report.pdf.asc --with-key alice.pub
+```
+
+`-o`/`--output` overrides the destination; `-` reads stdin or writes
+stdout. Verify exit codes: **0** good, **1** bad, **2** unknown signer.
+
+See [docs/usage.md → Signing and verifying with `tcli`](docs/usage.md#signing-and-verifying-with-tcli)
+for the full surface (email-ambiguity handling, card vs software
+backend, parse-time validation, limitations).
 
 ### Encryption
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ At a glance, tumpa-cli works as a drop-in for:
 Three binaries are provided:
 
 - **`tcli`** -- human-facing key management and SSH agent: import, export,
-  search, fetch, describe, list, delete, card status, agent daemons, sign and verification.
+  search, fetch, describe, list, delete, card status, agent daemons, signing and verification.
 - **`tclig`** -- GnuPG drop-in for programs that invoke `gpg` (git signing,
   `pass`, anything with a `gpg.program` hook)
 - **`tpass`** -- drop-in replacement for [password-store](https://www.passwordstore.org/)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,7 @@ and direct encryption/decryption.
 - [Password store (pass)](#password-store-pass)
 - [tpass — native password store](#tpass--native-password-store)
 - [Encryption and decryption](#encryption-and-decryption)
+- [Signing and verifying with `tcli`](#signing-and-verifying-with-tcli)
 - [Agent (passphrase cache + SSH)](#agent-passphrase-cache--ssh)
 - [Hardware OpenPGP cards](#hardware-openpgp-cards)
 - [Passphrase handling](#passphrase-handling)
@@ -819,6 +820,164 @@ Output:
 ```
 gpg: public key is CCD470033AD77830
 ```
+
+---
+
+## Signing and verifying with `tcli`
+
+`tcli` exposes three human-facing commands for OpenPGP signing and
+verification of arbitrary files. They are the user-friendly counterpart
+to the GPG-shape `tclig` flags that git and `pass` invoke under the
+hood: `tcli` picks signers by fingerprint, key ID, or **email**;
+defaults to ASCII armor; supports stdin/stdout via `-`; and returns
+script-friendly exit codes.
+
+| Command            | What it produces                                            |
+|--------------------|-------------------------------------------------------------|
+| `tcli --sign`      | Detached signature (`<file>.asc` armored, `<file>.sig` binary). |
+| `tcli --sign-inline` | Cleartext-signed message (`-----BEGIN PGP SIGNED MESSAGE-----`, software keys only). |
+| `tcli --verify`    | Verifies a detached or cleartext signature; exits 0/1/2.    |
+
+### Detached signatures
+
+Sign a file using its primary key (default = ASCII-armored,
+sibling `.asc`):
+
+```
+tcli --sign report.pdf --with-key 62162BC9FA951F481F8457D566B7F2009745BD06
+# writes report.pdf.asc
+```
+
+Use email instead of fingerprint:
+
+```
+tcli --sign report.pdf --with-key alice@example.com
+```
+
+Email matching is case-insensitive and exact. If multiple keys in the
+keystore share the same email, `tcli` lists them and refuses to pick;
+re-run with `--with-key <FINGERPRINT>` to disambiguate.
+
+Produce a binary `.sig` instead of `.asc`:
+
+```
+tcli --sign report.pdf --with-key alice@example.com --binary
+# writes report.pdf.sig
+```
+
+Override the destination with `-o`/`--output` (use `-` for stdout):
+
+```
+tcli --sign report.pdf --with-key alice@example.com -o /tmp/report.sig --binary
+cat report.pdf | tcli --sign - --with-key alice@example.com -o - > report.sig
+```
+
+Reading from stdin (`--sign -`) requires `-o`/`--output` because there
+is no input filename to derive a default destination from.
+
+### Inline (cleartext) signatures
+
+Cleartext signatures embed the original text inline between
+`-----BEGIN PGP SIGNED MESSAGE-----` and `-----BEGIN PGP SIGNATURE-----`.
+The signed message stays human-readable. Use `--sign-inline`:
+
+```
+tcli --sign-inline notice.txt --with-key alice@example.com
+# writes notice.txt.asc
+```
+
+Inline signing is **software-only** in this release — there is no
+card-based cleartext-signing primitive. If the chosen key has no
+software secret key in the keystore (card-only), `tcli` errors out
+with a clear message; use `--sign` (detached) for card-only keys.
+
+`--binary` is rejected on `--sign-inline` (cleartext is text by
+definition).
+
+### Verifying
+
+Verify a detached signature using a key from the keystore:
+
+```
+tcli --verify report.pdf --signature report.pdf.asc
+```
+
+Verify a cleartext-signed message in place (no separate signature
+file):
+
+```
+tcli --verify notice.txt.asc
+```
+
+Verify against an external public key file (skips the keystore
+entirely):
+
+```
+tcli --verify report.pdf --signature report.pdf.asc --with-key alice.pub
+tcli --verify notice.txt.asc --with-key alice.pub
+```
+
+`--with-key` on the verify side is always a path to a public-key file
+(armored or binary). To use a key already in the keystore, omit
+`--with-key`; `tcli` will look the signer up by issuer fingerprint /
+key ID embedded in the signature.
+
+Verify reads the data from stdin too:
+
+```
+cat report.pdf | tcli --verify - --signature report.pdf.asc
+```
+
+(Stdin verify always needs `--signature`; reading both data and an
+inline signature from stdin is not supported.)
+
+### Output and exit codes
+
+`tcli --verify` prints a human-readable report on stderr, listing
+every non-revoked UID (primary first, then `aka …`) plus the verifier
+fingerprint. Exit codes:
+
+| Code | Meaning                                                    |
+|------|------------------------------------------------------------|
+| `0`  | Good signature.                                            |
+| `1`  | BAD signature (signer is known, signature does not match). |
+| `2`  | Unknown signer (issuer key not in keystore, no `--with-key`). |
+
+Example success output:
+
+```
+tcli: Good signature from "Alice <alice@example.com>"
+tcli:                 aka "Alice <alice@work.example.com>"
+tcli: Primary key fingerprint: 62162BC9FA951F481F8457D566B7F2009745BD06
+```
+
+`tcli --sign` and `--sign-inline` print a one-line confirmation on
+stderr (`tcli: Wrote signature to <path>`) and the signing backend
+(`Signed with card …` or `Signed with software key …`). All real
+output goes to the file or stdout depending on `-o`.
+
+### Difference from `tclig`
+
+`tclig` is the GPG-shape drop-in invoked by git, `pass`, and similar
+tools. It uses `gpg`-style flags (`-bsau`, `--detach-sign`, `--verify`
+with `[GNUPG:]` status lines) and is unchanged by these `tcli`
+commands. You generally won't run `tclig` directly — let git/pass call
+it via the GPG-program hook (see [Git signing](#git-signing) and
+[Password store (pass)](#password-store-pass)).
+
+For ad-hoc signing of arbitrary files at the shell, prefer `tcli
+--sign / --sign-inline / --verify`: shorter flags, email-based key
+selection, sane defaults, sensible exit codes.
+
+### Limitations
+
+- `--verify` against an inline-armored signed message (the `gpg
+  --sign` form, not `gpg --clearsign`) requires `--with-key
+  <PUB_FILE>`. Keystore lookup on that path is not implemented; use
+  cleartext (`--sign-inline`) if you want the keystore-lookup
+  experience.
+- Card-based cleartext signing is not available; use detached
+  (`--sign`) for keys held only on a card.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -17,6 +17,7 @@ lint:
 # Run all tests (requires TUMPA_PASSPHRASE and a secret key in ~/.tumpa/keys.db)
 test: build
     TUMPA_PASSPHRASE="${TUMPA_PASSPHRASE}" ./tests/test_tpass.sh
+    TUMPA_PASSPHRASE="${TUMPA_PASSPHRASE}" ./tests/test_sign_verify.sh
 
 # Run cross-compatibility tests between tpass and pass
 test-compat: build
@@ -25,6 +26,10 @@ test-compat: build
 # Run tcli + pass integration tests
 test-pass: build
     TUMPA_PASSPHRASE="${TUMPA_PASSPHRASE}" ./tests/test_pass.sh
+
+# Run tcli sign/verify integration tests
+test-sign-verify: build
+    TUMPA_PASSPHRASE="${TUMPA_PASSPHRASE}" ./tests/test_sign_verify.sh
 
 # Run tcli key management tests (--import, --export, --info, --delete, --search)
 test-keystore: build
@@ -35,7 +40,7 @@ test-agent-cache: build
     TUMPA_PASSPHRASE="${TUMPA_PASSPHRASE}" ./tests/test_agent_no_bad_cache.sh
 
 # Run all test suites
-test-all: test test-compat test-pass test-keystore test-agent-cache
+test-all: test test-compat test-pass test-sign-verify test-keystore test-agent-cache
 
 # Build, lint, and test
 check: build lint test

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -187,24 +187,24 @@ async fn handle_client(
     while reader.read_line(&mut line).await? > 0 {
         let response = if let Some(request) = protocol::parse_request(&line) {
             match request {
-                protocol::Request::Get { fingerprint } => {
+                protocol::Request::Get { cache_key } => {
                     let cache = cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
-                    match cache.get(&fingerprint) {
+                    match cache.get(&cache_key) {
                         Some(pass) => protocol::Response::Passphrase(pass.clone()),
                         None => protocol::Response::NotFound,
                     }
                 }
                 protocol::Request::Put {
-                    fingerprint,
+                    cache_key,
                     passphrase,
                 } => {
                     let mut cache = cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
-                    cache.store(&fingerprint, passphrase);
+                    cache.store(&cache_key, passphrase);
                     protocol::Response::Ok
                 }
-                protocol::Request::Clear { fingerprint } => {
+                protocol::Request::Clear { cache_key } => {
                     let mut cache = cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
-                    cache.remove(&fingerprint);
+                    cache.remove(&cache_key);
                     protocol::Response::Ok
                 }
             }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -113,8 +113,8 @@ pub async fn run_agent(
     // Set restrictive umask for socket creation
     let old_umask = unsafe { libc::umask(0o177) };
 
-    let listener = UnixListener::bind(&socket_path)
-        .context(format!("Failed to bind {:?}", socket_path))?;
+    let listener =
+        UnixListener::bind(&socket_path).context(format!("Failed to bind {:?}", socket_path))?;
 
     // Restore umask
     unsafe {
@@ -149,9 +149,7 @@ pub async fn run_agent(
 
         let ks_path = keystore_path.clone();
         tokio::spawn(async move {
-            if let Err(e) =
-                crate::ssh::run_agent_with_cache(&ssh_host, ks_path, ssh_cache).await
-            {
+            if let Err(e) = crate::ssh::run_agent_with_cache(&ssh_host, ks_path, ssh_cache).await {
                 eprintln!("SSH agent error: {}", e);
             }
         });
@@ -200,14 +198,12 @@ async fn handle_client(
                     fingerprint,
                     passphrase,
                 } => {
-                    let mut cache =
-                        cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
+                    let mut cache = cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
                     cache.store(&fingerprint, passphrase);
                     protocol::Response::Ok
                 }
                 protocol::Request::Clear { fingerprint } => {
-                    let mut cache =
-                        cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
+                    let mut cache = cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
                     cache.remove(&fingerprint);
                     protocol::Response::Ok
                 }

--- a/src/agent/protocol.rs
+++ b/src/agent/protocol.rs
@@ -3,36 +3,51 @@
 //! Simple line-based protocol over Unix socket:
 //!
 //! ```text
-//! Client → Agent:  GET_PASSPHRASE <fingerprint>\n
+//! Client → Agent:  GET_PASSPHRASE <cache-key>\n
 //! Agent → Client:  PASSPHRASE <base64>\n  or  NOT_FOUND\n
 //!
-//! Client → Agent:  PUT_PASSPHRASE <fingerprint> <base64>\n
+//! Client → Agent:  PUT_PASSPHRASE <cache-key> <base64>\n
 //! Agent → Client:  OK\n
 //!
-//! Client → Agent:  CLEAR_PASSPHRASE <fingerprint>\n
+//! Client → Agent:  CLEAR_PASSPHRASE <cache-key>\n
 //! Agent → Client:  OK\n
 //! ```
 
 use anyhow::{Context, Result};
 use zeroize::Zeroizing;
 
-/// Validate that a fingerprint is a hex string of 16 or 40 characters.
-fn is_valid_fingerprint(s: &str) -> bool {
-    let len = s.len();
-    (len == 16 || len == 40) && s.chars().all(|c| c.is_ascii_hexdigit())
+/// Validate an agent cache key.
+///
+/// Raw fingerprint keys are 16 or 40 hex chars. Namespaced cache keys use
+/// `<slot>:<fingerprint>`, where slot is `pin` or `passphrase`.
+fn is_valid_cache_key(s: &str) -> bool {
+    fn is_valid_fingerprint(s: &str) -> bool {
+        let len = s.len();
+        (len == 16 || len == 40) && s.chars().all(|c| c.is_ascii_hexdigit())
+    }
+
+    if is_valid_fingerprint(s) {
+        return true;
+    }
+
+    let Some((slot, fingerprint)) = s.split_once(':') else {
+        return false;
+    };
+
+    matches!(slot, "pin" | "passphrase") && is_valid_fingerprint(fingerprint)
 }
 
 /// A request from a client to the agent.
 pub enum Request {
     Get {
-        fingerprint: String,
+        cache_key: String,
     },
     Put {
-        fingerprint: String,
+        cache_key: String,
         passphrase: Zeroizing<String>,
     },
     Clear {
-        fingerprint: String,
+        cache_key: String,
     },
 }
 
@@ -47,24 +62,24 @@ pub enum Response {
 pub fn parse_request(line: &str) -> Option<Request> {
     let line = line.trim();
 
-    if let Some(fp) = line.strip_prefix("GET_PASSPHRASE ") {
-        let fp = fp.trim();
-        if is_valid_fingerprint(fp) {
+    if let Some(cache_key) = line.strip_prefix("GET_PASSPHRASE ") {
+        let cache_key = cache_key.trim();
+        if is_valid_cache_key(cache_key) {
             return Some(Request::Get {
-                fingerprint: fp.to_string(),
+                cache_key: cache_key.to_string(),
             });
         }
     }
 
     if let Some(rest) = line.strip_prefix("PUT_PASSPHRASE ") {
         let mut parts = rest.splitn(2, ' ');
-        if let (Some(fp), Some(b64)) = (parts.next(), parts.next()) {
-            let fp = fp.trim();
+        if let (Some(cache_key), Some(b64)) = (parts.next(), parts.next()) {
+            let cache_key = cache_key.trim();
             let b64 = b64.trim();
-            if is_valid_fingerprint(fp) && !b64.is_empty() {
+            if is_valid_cache_key(cache_key) && !b64.is_empty() {
                 if let Ok(decoded) = base64_decode(b64) {
                     return Some(Request::Put {
-                        fingerprint: fp.to_string(),
+                        cache_key: cache_key.to_string(),
                         passphrase: decoded,
                     });
                 }
@@ -72,11 +87,11 @@ pub fn parse_request(line: &str) -> Option<Request> {
         }
     }
 
-    if let Some(fp) = line.strip_prefix("CLEAR_PASSPHRASE ") {
-        let fp = fp.trim();
-        if is_valid_fingerprint(fp) {
+    if let Some(cache_key) = line.strip_prefix("CLEAR_PASSPHRASE ") {
+        let cache_key = cache_key.trim();
+        if is_valid_cache_key(cache_key) {
             return Some(Request::Clear {
-                fingerprint: fp.to_string(),
+                cache_key: cache_key.to_string(),
             });
         }
     }
@@ -126,4 +141,38 @@ fn base64_decode(s: &str) -> Result<Zeroizing<String>> {
         .context("Invalid base64")?;
     let s = String::from_utf8(bytes).context("Invalid UTF-8")?;
     Ok(Zeroizing::new(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_request, Request};
+
+    #[test]
+    fn parse_request_accepts_namespaced_cache_keys() {
+        let get = parse_request("GET_PASSPHRASE pin:0123456789ABCDEF\n");
+        assert!(matches!(
+            get,
+            Some(Request::Get { cache_key }) if cache_key == "pin:0123456789ABCDEF"
+        ));
+
+        let put = parse_request("PUT_PASSPHRASE passphrase:0123456789ABCDEF c2VjcmV0\n");
+        assert!(matches!(
+            put,
+            Some(Request::Put { cache_key, .. }) if cache_key == "passphrase:0123456789ABCDEF"
+        ));
+
+        let clear =
+            parse_request("CLEAR_PASSPHRASE passphrase:0123456789ABCDEF0123456789ABCDEF01234567\n");
+        assert!(matches!(
+            clear,
+            Some(Request::Clear { cache_key })
+                if cache_key == "passphrase:0123456789ABCDEF0123456789ABCDEF01234567"
+        ));
+    }
+
+    #[test]
+    fn parse_request_rejects_invalid_namespaced_cache_keys() {
+        assert!(parse_request("GET_PASSPHRASE other:0123456789ABCDEF\n").is_none());
+        assert!(parse_request("GET_PASSPHRASE pin:not-hex\n").is_none());
+    }
 }

--- a/src/agent/protocol.rs
+++ b/src/agent/protocol.rs
@@ -24,9 +24,16 @@ fn is_valid_fingerprint(s: &str) -> bool {
 
 /// A request from a client to the agent.
 pub enum Request {
-    Get { fingerprint: String },
-    Put { fingerprint: String, passphrase: Zeroizing<String> },
-    Clear { fingerprint: String },
+    Get {
+        fingerprint: String,
+    },
+    Put {
+        fingerprint: String,
+        passphrase: Zeroizing<String>,
+    },
+    Clear {
+        fingerprint: String,
+    },
 }
 
 /// A response from the agent to a client.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,13 +13,11 @@ use clap_complete::Shell;
 #[clap(name = "tcli", version)]
 pub struct Args {
     // --- Key listing ---
-
     /// List keys in the tumpa keystore (human-readable).
     #[clap(long)]
     pub list_keys: bool,
 
     // --- Key management ---
-
     /// Import keys from files or directories.
     #[clap(long)]
     pub import: bool,
@@ -57,8 +55,39 @@ pub struct Args {
     #[clap(long)]
     pub card_status: bool,
 
-    // --- Output ---
+    // --- Signing and verification ---
+    /// Create a detached signature for FILE (use `-` for stdin).
+    /// Default output is `<FILE>.asc` (ASCII-armored). Combine with
+    /// `--binary` for `<FILE>.sig` (binary). Override the destination
+    /// with `-o`/`--output` (`-` writes to stdout).
+    #[clap(long, value_name = "FILE")]
+    pub sign: Option<PathBuf>,
 
+    /// Create an inline (cleartext, `-----BEGIN PGP SIGNED MESSAGE-----`)
+    /// signature for FILE (use `-` for stdin). Default output is
+    /// `<FILE>.asc`; override with `-o`/`--output`. Software keys only —
+    /// card-only keys are rejected.
+    #[clap(long, value_name = "FILE")]
+    pub sign_inline: Option<PathBuf>,
+
+    /// Verify a signature on FILE (use `-` for stdin). For a detached
+    /// signature, also pass `--signature SIG_FILE`. Without `--signature`
+    /// the file itself must contain a cleartext-signed message.
+    #[clap(long, value_name = "FILE")]
+    pub verify: Option<PathBuf>,
+
+    /// Signing key for `--sign` / `--sign-inline`: fingerprint, key ID,
+    /// or exact email.
+    /// For `--verify`: path to a public key file to verify against
+    /// (omit to look the signer up in the keystore by issuer ID).
+    #[clap(long, value_name = "FP|KEYID|EMAIL or FILE")]
+    pub with_key: Option<String>,
+
+    /// Detached signature file (only valid with `--verify`).
+    #[clap(long, value_name = "SIG_FILE")]
+    pub signature: Option<PathBuf>,
+
+    // --- Output ---
     /// Output ASCII-armored data (for --export).
     #[clap(long, short = 'a')]
     pub armor: bool,
@@ -89,7 +118,6 @@ pub struct Args {
 
     // --- Experimental (compile-time gated behind the `experimental`
     // Cargo feature; the flags below only exist on feature builds).
-
     /// **Experimental.** Upload a secret key from the keystore to the
     /// signing slot of a connected OpenPGP smart card. If the key has
     /// both a sign-capable primary key and a sign-capable subkey,
@@ -153,24 +181,20 @@ pub struct Args {
     pub include_authentication: bool,
 
     // --- Positional ---
-
     /// Positional arguments (input files for --import).
     pub input_files: Vec<String>,
 
     // --- Keystore ---
-
     /// Path to tumpa keystore database. Defaults to ~/.tumpa/keys.db.
     #[clap(long, env = "TUMPA_KEYSTORE")]
     pub keystore: Option<PathBuf>,
 
     // --- SSH agent ---
-
     /// SSH agent subcommand.
     #[clap(subcommand)]
     pub subcmd: Option<SubCommand>,
 
     // --- Shell completions ---
-
     /// Generate shell completions and print to stdout.
     #[clap(long, value_name = "SHELL", value_enum)]
     pub completions: Option<Shell>,
@@ -217,7 +241,7 @@ pub enum SubCommand {
 }
 
 #[cfg(feature = "experimental")]
-pub use tumpa_cli::upload_card::WhichKey;
+pub use crate::upload_card::WhichKey;
 
 #[derive(Debug)]
 pub enum Mode {
@@ -283,7 +307,28 @@ pub enum Mode {
     Completions {
         shell: Shell,
     },
+    Sign {
+        input: PathBuf,
+        with_key: String,
+        binary: bool,
+        output: Option<PathBuf>,
+    },
+    SignInline {
+        input: PathBuf,
+        with_key: String,
+        output: Option<PathBuf>,
+    },
+    Verify {
+        input: PathBuf,
+        signature: Option<PathBuf>,
+        with_key_file: Option<PathBuf>,
+    },
     None,
+}
+
+/// Returns true if `path` is the literal `-` stdin/stdout sentinel.
+pub fn is_stdio(path: &std::path::Path) -> bool {
+    path.as_os_str() == "-"
 }
 
 impl TryFrom<Args> for Mode {
@@ -329,6 +374,132 @@ impl TryFrom<Args> for Mode {
             return Ok(Mode::Completions { shell });
         }
 
+        // --- Signing and verification ---
+        //
+        // `--sign`, `--sign-inline`, `--verify` are pairwise exclusive
+        // and exclusive with every other action flag and with positional
+        // input files. They are checked *before* the card-status / list
+        // / experimental / key-management blocks below so that "tcli
+        // --sign foo" never falls through to a different mode silently.
+        let sign_count = [
+            value.sign.is_some(),
+            value.sign_inline.is_some(),
+            value.verify.is_some(),
+        ]
+        .iter()
+        .filter(|v| **v)
+        .count();
+        if sign_count > 1 {
+            return Err("--sign, --sign-inline, and --verify are mutually exclusive".to_string());
+        }
+        if sign_count == 1 {
+            // Reject conflicts with other action / modifier flags.
+            if value.list_keys
+                || value.import
+                || value.export.is_some()
+                || value.info.is_some()
+                || value.desc.is_some()
+                || value.delete.is_some()
+                || value.search.is_some()
+                || value.fetch.is_some()
+                || value.show_socket.is_some()
+                || value.card_status
+                || value.list_cards
+                || !value.input_files.is_empty()
+                || value.armor
+                || value.recursive
+                || value.force
+                || value.dry_run
+                || value.email
+            {
+                return Err(
+                    "--sign / --sign-inline / --verify cannot be combined with other action flags"
+                        .to_string(),
+                );
+            }
+
+            // --signature only valid with --verify.
+            if value.signature.is_some() && value.verify.is_none() {
+                return Err("--signature is only valid with --verify".to_string());
+            }
+
+            // --binary only valid with --sign (cleartext is text-only;
+            // verify never produces output).
+            if value.binary && value.sign.is_none() {
+                return Err(
+                    "--binary is only valid with --sign (cleartext signatures are text-only)"
+                        .to_string(),
+                );
+            }
+
+            // --output only valid with --sign / --sign-inline.
+            if value.output.is_some() && value.verify.is_some() {
+                return Err("--output is not valid with --verify".to_string());
+            }
+
+            if let Some(input) = value.sign.clone() {
+                let with_key = value
+                    .with_key
+                    .clone()
+                    .ok_or("--sign requires --with-key FP|KEYID|EMAIL")?;
+                if is_stdio(&input) && value.output.is_none() {
+                    return Err(
+                        "--sign reading from stdin requires -o/--output (no input file to derive a default path from)"
+                            .to_string(),
+                    );
+                }
+                return Ok(Mode::Sign {
+                    input,
+                    with_key,
+                    binary: value.binary,
+                    output: value.output.clone(),
+                });
+            }
+
+            if let Some(input) = value.sign_inline.clone() {
+                let with_key = value
+                    .with_key
+                    .clone()
+                    .ok_or("--sign-inline requires --with-key FP|KEYID|EMAIL")?;
+                if is_stdio(&input) && value.output.is_none() {
+                    return Err(
+                        "--sign-inline reading from stdin requires -o/--output (no input file to derive a default path from)"
+                            .to_string(),
+                    );
+                }
+                return Ok(Mode::SignInline {
+                    input,
+                    with_key,
+                    output: value.output.clone(),
+                });
+            }
+
+            if let Some(input) = value.verify.clone() {
+                if value.signature.is_none() && is_stdio(&input) {
+                    return Err(
+                        "--verify reading from stdin requires --signature SIG_FILE (cannot read both data and inline signature from stdin)"
+                            .to_string(),
+                    );
+                }
+                let with_key_file = value.with_key.clone().map(PathBuf::from);
+                return Ok(Mode::Verify {
+                    input,
+                    signature: value.signature.clone(),
+                    with_key_file,
+                });
+            }
+        } else {
+            // No sign/verify in play — these companion flags are stray.
+            if value.signature.is_some() {
+                return Err("--signature is only valid with --verify".to_string());
+            }
+            if value.with_key.is_some() {
+                return Err(
+                    "--with-key is only valid with --sign / --sign-inline / --verify".to_string(),
+                );
+            }
+        }
+
         // --- Card and socket info ---
 
         if value.card_status {
@@ -354,6 +525,11 @@ impl TryFrom<Args> for Mode {
                 || value.show_socket.is_some()
                 || value.card_status
                 || value.completions.is_some()
+                || value.sign.is_some()
+                || value.sign_inline.is_some()
+                || value.verify.is_some()
+                || value.signature.is_some()
+                || value.with_key.is_some()
                 || !value.input_files.is_empty()
                 || value.armor
                 || value.binary
@@ -375,9 +551,7 @@ impl TryFrom<Args> for Mode {
                     || value.include_encryption
                     || value.include_authentication
                 {
-                    return Err(
-                        "--list-cards cannot be combined with other flags".to_string(),
-                    );
+                    return Err("--list-cards cannot be combined with other flags".to_string());
                 }
             }
             return Ok(Mode::ListCards);
@@ -400,12 +574,10 @@ impl TryFrom<Args> for Mode {
                     }
                 };
                 if value.include_signing && which == Some(WhichKey::Primary) {
-                    return Err(
-                        "--include-signing contradicts --which primary; \
+                    return Err("--include-signing contradicts --which primary; \
                          --include-signing means \"signing subkey into the \
                          signing slot\""
-                            .to_string(),
-                    );
+                        .to_string());
                 }
                 return Ok(Mode::UploadToCard {
                     key_id,
@@ -421,15 +593,10 @@ impl TryFrom<Args> for Mode {
                 return Err("--which only applies to --upload-to-card".to_string());
             }
 
-            if value.include_signing
-                || value.include_encryption
-                || value.include_authentication
-            {
-                return Err(
-                    "--include-signing / --include-encryption / \
+            if value.include_signing || value.include_encryption || value.include_authentication {
+                return Err("--include-signing / --include-encryption / \
                      --include-authentication only apply to --upload-to-card"
-                        .to_string(),
-                );
+                    .to_string());
             }
 
             if value.reset_card {
@@ -515,10 +682,8 @@ mod tests {
     use clap::Parser;
 
     fn parse(argv: &[&str]) -> Result<Mode, String> {
-        let args = Args::try_parse_from(
-            std::iter::once("tcli").chain(argv.iter().copied()),
-        )
-        .map_err(|e| e.to_string())?;
+        let args = Args::try_parse_from(std::iter::once("tcli").chain(argv.iter().copied()))
+            .map_err(|e| e.to_string())?;
         Mode::try_from(args)
     }
 
@@ -548,7 +713,11 @@ mod tests {
     #[test]
     fn list_cards_rejects_modifier_flags() {
         // Spot-check one modifier from each family (bool and Option).
-        for extra in [&["--armor"][..], &["--output", "/tmp/x"][..], &["--email"][..]] {
+        for extra in [
+            &["--armor"][..],
+            &["--output", "/tmp/x"][..],
+            &["--email"][..],
+        ] {
             let mut argv = vec!["--list-cards"];
             argv.extend_from_slice(extra);
             let err = parse(&argv).unwrap_err();
@@ -561,8 +730,7 @@ mod tests {
 
     #[test]
     fn list_cards_rejects_subcommand() {
-        let err = parse(&["--list-cards", "ssh-agent", "-H", "unix:///tmp/s"])
-            .unwrap_err();
+        let err = parse(&["--list-cards", "ssh-agent", "-H", "unix:///tmp/s"]).unwrap_err();
         assert!(
             err.contains("--list-cards cannot be combined"),
             "got: {err}"
@@ -572,8 +740,7 @@ mod tests {
     #[cfg(feature = "experimental")]
     #[test]
     fn list_cards_rejects_card_ident() {
-        let err =
-            parse(&["--list-cards", "--card-ident", "000F:ABCD"]).unwrap_err();
+        let err = parse(&["--list-cards", "--card-ident", "000F:ABCD"]).unwrap_err();
         assert!(
             err.contains("--list-cards cannot be combined"),
             "got: {err}"
@@ -584,18 +751,13 @@ mod tests {
     #[test]
     fn card_ident_without_upload_or_reset_errors() {
         let err = parse(&["--card-ident", "000F:ABCD"]).unwrap_err();
-        assert!(
-            err.contains("--card-ident only applies to"),
-            "got: {err}"
-        );
+        assert!(err.contains("--card-ident only applies to"), "got: {err}");
     }
 
     #[cfg(feature = "experimental")]
     #[test]
     fn upload_to_card_threads_card_ident() {
-        let mode =
-            parse(&["--upload-to-card", "ABCDEF", "--card-ident", "000F:ABCD"])
-                .unwrap();
+        let mode = parse(&["--upload-to-card", "ABCDEF", "--card-ident", "000F:ABCD"]).unwrap();
         match mode {
             Mode::UploadToCard {
                 key_id,
@@ -612,7 +774,10 @@ mod tests {
                 assert!(!include_encryption);
                 assert!(!include_authentication);
             }
-            other => panic!("expected UploadToCard, got {:?}", std::mem::discriminant(&other)),
+            other => panic!(
+                "expected UploadToCard, got {:?}",
+                std::mem::discriminant(&other)
+            ),
         }
     }
 
@@ -639,7 +804,10 @@ mod tests {
                 assert!(include_encryption);
                 assert!(include_authentication);
             }
-            other => panic!("expected UploadToCard, got {:?}", std::mem::discriminant(&other)),
+            other => panic!(
+                "expected UploadToCard, got {:?}",
+                std::mem::discriminant(&other)
+            ),
         }
     }
 
@@ -647,36 +815,25 @@ mod tests {
     #[test]
     fn include_subkey_flags_require_upload_to_card() {
         let err = parse(&["--include-signing"]).unwrap_err();
-        assert!(
-            err.contains("only apply to --upload-to-card"),
-            "got: {err}"
-        );
+        assert!(err.contains("only apply to --upload-to-card"), "got: {err}");
         let err = parse(&["--include-encryption"]).unwrap_err();
-        assert!(
-            err.contains("only apply to --upload-to-card"),
-            "got: {err}"
-        );
+        assert!(err.contains("only apply to --upload-to-card"), "got: {err}");
         let err = parse(&["--include-authentication"]).unwrap_err();
-        assert!(
-            err.contains("only apply to --upload-to-card"),
-            "got: {err}"
-        );
+        assert!(err.contains("only apply to --upload-to-card"), "got: {err}");
     }
 
     #[cfg(feature = "experimental")]
     #[test]
     fn include_signing_threads_through_mode() {
-        let mode = parse(&[
-            "--upload-to-card",
-            "ABCDEF",
-            "--include-signing",
-        ])
-        .unwrap();
+        let mode = parse(&["--upload-to-card", "ABCDEF", "--include-signing"]).unwrap();
         match mode {
             Mode::UploadToCard {
                 include_signing, ..
             } => assert!(include_signing),
-            other => panic!("expected UploadToCard, got {:?}", std::mem::discriminant(&other)),
+            other => panic!(
+                "expected UploadToCard, got {:?}",
+                std::mem::discriminant(&other)
+            ),
         }
     }
 
@@ -691,10 +848,7 @@ mod tests {
             "--include-signing",
         ])
         .unwrap_err();
-        assert!(
-            err.contains("contradicts --which primary"),
-            "got: {err}"
-        );
+        assert!(err.contains("contradicts --which primary"), "got: {err}");
     }
 
     #[cfg(feature = "experimental")]
@@ -705,7 +859,271 @@ mod tests {
             Mode::ResetCard { card_ident } => {
                 assert_eq!(card_ident.as_deref(), Some("000F:ABCD"));
             }
-            other => panic!("expected ResetCard, got {:?}", std::mem::discriminant(&other)),
+            other => panic!(
+                "expected ResetCard, got {:?}",
+                std::mem::discriminant(&other)
+            ),
         }
+    }
+
+    // ----- sign / sign-inline / verify -----
+
+    #[test]
+    fn sign_with_fp_parses_to_armored_default() {
+        let mode = parse(&[
+            "--sign",
+            "msg.txt",
+            "--with-key",
+            "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD",
+        ])
+        .unwrap();
+        match mode {
+            Mode::Sign {
+                input,
+                with_key,
+                binary,
+                output,
+            } => {
+                assert_eq!(input, PathBuf::from("msg.txt"));
+                assert_eq!(with_key, "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD");
+                assert!(!binary, "default must be armored");
+                assert!(output.is_none(), "default output is sibling .asc");
+            }
+            other => panic!("expected Sign, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn sign_with_email_parses() {
+        let mode = parse(&["--sign", "msg.txt", "--with-key", "alice@example.com"]).unwrap();
+        match mode {
+            Mode::Sign { with_key, .. } => assert_eq!(with_key, "alice@example.com"),
+            other => panic!("expected Sign, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn sign_binary_threads_through() {
+        let mode = parse(&[
+            "--sign",
+            "msg.txt",
+            "--with-key",
+            "alice@example.com",
+            "--binary",
+        ])
+        .unwrap();
+        match mode {
+            Mode::Sign { binary, .. } => assert!(binary),
+            other => panic!("expected Sign, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn sign_output_threads_through() {
+        let mode = parse(&[
+            "--sign",
+            "msg.txt",
+            "--with-key",
+            "alice@example.com",
+            "-o",
+            "/tmp/x.asc",
+        ])
+        .unwrap();
+        match mode {
+            Mode::Sign { output, .. } => {
+                assert_eq!(output.as_deref(), Some(std::path::Path::new("/tmp/x.asc")))
+            }
+            other => panic!("expected Sign, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn sign_requires_with_key() {
+        let err = parse(&["--sign", "msg.txt"]).unwrap_err();
+        assert!(err.contains("--with-key"), "got: {err}");
+    }
+
+    #[test]
+    fn sign_inline_parses() {
+        let mode = parse(&[
+            "--sign-inline",
+            "msg.txt",
+            "--with-key",
+            "alice@example.com",
+        ])
+        .unwrap();
+        match mode {
+            Mode::SignInline {
+                input,
+                with_key,
+                output,
+            } => {
+                assert_eq!(input, PathBuf::from("msg.txt"));
+                assert_eq!(with_key, "alice@example.com");
+                assert!(output.is_none());
+            }
+            other => panic!(
+                "expected SignInline, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn sign_inline_rejects_binary() {
+        let err = parse(&[
+            "--sign-inline",
+            "msg.txt",
+            "--with-key",
+            "alice@example.com",
+            "--binary",
+        ])
+        .unwrap_err();
+        assert!(
+            err.contains("--binary is only valid with --sign"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn sign_inline_requires_with_key() {
+        let err = parse(&["--sign-inline", "msg.txt"]).unwrap_err();
+        assert!(err.contains("--with-key"), "got: {err}");
+    }
+
+    #[test]
+    fn verify_inline_parses() {
+        let mode = parse(&["--verify", "msg.txt.asc"]).unwrap();
+        match mode {
+            Mode::Verify {
+                input,
+                signature,
+                with_key_file,
+            } => {
+                assert_eq!(input, PathBuf::from("msg.txt.asc"));
+                assert!(signature.is_none());
+                assert!(with_key_file.is_none());
+            }
+            other => panic!("expected Verify, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn verify_detached_parses() {
+        let mode = parse(&["--verify", "msg.txt", "--signature", "msg.txt.sig"]).unwrap();
+        match mode {
+            Mode::Verify {
+                input, signature, ..
+            } => {
+                assert_eq!(input, PathBuf::from("msg.txt"));
+                assert_eq!(
+                    signature.as_deref(),
+                    Some(std::path::Path::new("msg.txt.sig"))
+                );
+            }
+            other => panic!("expected Verify, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn verify_with_external_pubkey_parses() {
+        let mode = parse(&["--verify", "msg.txt.asc", "--with-key", "alice.pub"]).unwrap();
+        match mode {
+            Mode::Verify { with_key_file, .. } => {
+                assert_eq!(
+                    with_key_file.as_deref(),
+                    Some(std::path::Path::new("alice.pub"))
+                );
+            }
+            other => panic!("expected Verify, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn signature_without_verify_errors() {
+        let err = parse(&["--list-keys", "--signature", "x.sig"]).unwrap_err();
+        assert!(err.contains("--signature"), "got: {err}");
+    }
+
+    #[test]
+    fn with_key_without_sign_or_verify_errors() {
+        let err = parse(&["--list-keys", "--with-key", "alice@example.com"]).unwrap_err();
+        assert!(err.contains("--with-key"), "got: {err}");
+    }
+
+    #[test]
+    fn sign_and_verify_are_mutually_exclusive() {
+        let err = parse(&[
+            "--sign",
+            "a.txt",
+            "--verify",
+            "b.txt",
+            "--with-key",
+            "alice@example.com",
+        ])
+        .unwrap_err();
+        assert!(err.contains("mutually exclusive"), "got: {err}");
+    }
+
+    #[test]
+    fn sign_and_sign_inline_are_mutually_exclusive() {
+        let err = parse(&[
+            "--sign",
+            "a.txt",
+            "--sign-inline",
+            "a.txt",
+            "--with-key",
+            "alice@example.com",
+        ])
+        .unwrap_err();
+        assert!(err.contains("mutually exclusive"), "got: {err}");
+    }
+
+    #[test]
+    fn sign_conflicts_with_other_actions() {
+        let err = parse(&[
+            "--sign",
+            "a.txt",
+            "--with-key",
+            "alice@example.com",
+            "--list-keys",
+        ])
+        .unwrap_err();
+        assert!(
+            err.contains("cannot be combined with other action flags"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn sign_stdin_requires_output() {
+        let err = parse(&["--sign", "-", "--with-key", "alice@example.com"]).unwrap_err();
+        assert!(err.contains("requires -o/--output"), "got: {err}");
+    }
+
+    #[test]
+    fn sign_stdin_with_output_ok() {
+        let mode = parse(&["--sign", "-", "--with-key", "alice@example.com", "-o", "-"]).unwrap();
+        match mode {
+            Mode::Sign { input, output, .. } => {
+                assert!(is_stdio(&input));
+                assert_eq!(output.as_deref().map(is_stdio), Some(true));
+            }
+            other => panic!("expected Sign, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn verify_stdin_inline_errors_without_signature() {
+        let err = parse(&["--verify", "-"]).unwrap_err();
+        assert!(err.contains("--signature"), "got: {err}");
+    }
+
+    #[test]
+    fn list_cards_rejects_sign_flag() {
+        // The order in which the two mutual-exclusion checks fire isn't
+        // load-bearing; what matters is that the combination is rejected.
+        let err = parse(&["--list-cards", "--sign", "x"]).unwrap_err();
+        assert!(err.contains("cannot be combined"), "got: {err}");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,11 +76,11 @@ pub struct Args {
     #[clap(long, value_name = "FILE")]
     pub verify: Option<PathBuf>,
 
-    /// Signing key for `--sign` / `--sign-inline`: fingerprint, key ID,
-    /// or exact email.
+    /// For `--sign` / `--sign-inline`: signer identifier
+    /// (fingerprint, key ID, or exact email).
     /// For `--verify`: path to a public key file to verify against
     /// (omit to look the signer up in the keystore by issuer ID).
-    #[clap(long, value_name = "FP|KEYID|EMAIL or FILE")]
+    #[clap(long, value_name = "SIGNER|PUBKEY_FILE")]
     pub with_key: Option<String>,
 
     /// Detached signature file (only valid with `--verify`).
@@ -340,6 +340,20 @@ impl TryFrom<Args> for Mode {
         // silently consume the invocation and ignore --list-cards.
         if value.list_cards && value.subcmd.is_some() {
             return Err("--list-cards cannot be combined with other flags".to_string());
+        }
+
+        // Sign/verify flags must also beat subcommands; otherwise the
+        // early subcommand dispatch below would silently ignore them.
+        if value.subcmd.is_some()
+            && (value.sign.is_some()
+                || value.sign_inline.is_some()
+                || value.verify.is_some()
+                || value.signature.is_some()
+                || value.with_key.is_some())
+        {
+            return Err(
+                "subcommands cannot be combined with --sign / --sign-inline / --verify".to_string(),
+            );
         }
 
         // Subcommands
@@ -1125,5 +1139,20 @@ mod tests {
         // load-bearing; what matters is that the combination is rejected.
         let err = parse(&["--list-cards", "--sign", "x"]).unwrap_err();
         assert!(err.contains("cannot be combined"), "got: {err}");
+    }
+
+    #[test]
+    fn subcommand_rejects_sign_flag() {
+        let err = parse(&[
+            "--sign",
+            "msg.txt",
+            "--with-key",
+            "abc",
+            "ssh-agent",
+            "--host",
+            "sock",
+        ])
+        .unwrap_err();
+        assert!(err.contains("subcommands cannot be combined"), "got: {err}");
     }
 }

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -120,11 +120,11 @@ fn try_decrypt_on_card(
 
     match ltd::decrypt_on_card(&card.key_data, ciphertext, &pin_obj, Some(&card.card.ident)) {
         Ok(z) => {
-            pinentry::cache_passphrase(&card.key_info.fingerprint, &pin);
+            pinentry::cache_pin(&card.key_info.fingerprint, &pin);
             Ok(Zeroizing::new(z.to_vec()))
         }
         Err(e) => {
-            pinentry::clear_cached_passphrase(&card.key_info.fingerprint);
+            pinentry::clear_cached_pin(&card.key_info.fingerprint);
             Err(anyhow::anyhow!("{e}")).context("Card decryption failed")
         }
     }

--- a/src/gpg/encrypt.rs
+++ b/src/gpg/encrypt.rs
@@ -35,9 +35,10 @@ pub fn encrypt(
     };
 
     let recip_refs: Vec<&str> = recipients.iter().map(|s| s.as_str()).collect();
-    let ciphertext = libtumpa::encrypt::encrypt_to_recipients(&keystore, &recip_refs, &plaintext, armor)
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .context("Encryption failed")?;
+    let ciphertext =
+        libtumpa::encrypt::encrypt_to_recipients(&keystore, &recip_refs, &plaintext, armor)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("Encryption failed")?;
 
     std::fs::write(output, &ciphertext)
         .context(format!("Failed to write output file {:?}", output))?;

--- a/src/gpg/keys.rs
+++ b/src/gpg/keys.rs
@@ -14,10 +14,7 @@ fn sanitize_uid(uid: &str) -> String {
 ///
 /// `pass` parses this to find encryption subkey key IDs:
 ///   grep '^sub:...*e[a-zA-Z]*:' to extract encryption-capable subkey IDs.
-pub fn list_keys_colon(
-    key_ids: &[String],
-    keystore_path: Option<&PathBuf>,
-) -> Result<()> {
+pub fn list_keys_colon(key_ids: &[String], keystore_path: Option<&PathBuf>) -> Result<()> {
     let keystore = store::open_keystore(keystore_path)?;
 
     let keys = if key_ids.is_empty() {
@@ -104,9 +101,7 @@ pub fn list_keys_colon(
 /// List secret keys in colon-delimited format (GPG --list-secret-keys --with-colons).
 ///
 /// `pass` bash completion parses field 10 (UID) from these lines.
-pub fn list_secret_keys_colon(
-    keystore_path: Option<&PathBuf>,
-) -> Result<()> {
+pub fn list_secret_keys_colon(keystore_path: Option<&PathBuf>) -> Result<()> {
     let keystore = store::open_keystore(keystore_path)?;
     let keys = keystore.list_secret_keys()?;
 

--- a/src/gpg/sign.rs
+++ b/src/gpg/sign.rs
@@ -5,9 +5,7 @@ use std::path::PathBuf;
 use anyhow::{anyhow, Context, Result};
 use zeroize::Zeroizing;
 
-use libtumpa::sign::{
-    sign_detached as libtumpa_sign_detached, Secret, SecretRequest, SignBackend,
-};
+use libtumpa::sign::{sign_detached as libtumpa_sign_detached, Secret, SecretRequest, SignBackend};
 use libtumpa::{Passphrase, Pin};
 
 use crate::pinentry;
@@ -82,12 +80,17 @@ pub fn sign(
     let (signature, backend) = match result {
         Ok(ok) => {
             if let Some(secret) = last_secret.borrow().as_ref() {
-                pinentry::cache_passphrase(&key_info.fingerprint, secret);
+                match backend_secret_kind(&ok.1) {
+                    SecretKind::Pin => pinentry::cache_pin(&key_info.fingerprint, secret),
+                    SecretKind::Passphrase => {
+                        pinentry::cache_passphrase(&key_info.fingerprint, secret)
+                    }
+                }
             }
             ok
         }
         Err(e) => {
-            pinentry::clear_cached_passphrase(&key_info.fingerprint);
+            pinentry::clear_all_cached_secrets(&key_info.fingerprint);
             return Err(anyhow!("{e}"));
         }
     };
@@ -129,7 +132,7 @@ pub fn sign(
 ///
 /// Returns `Zeroizing<String>` so the secret is wiped from memory when
 /// the value is dropped — never converted to a plain `String`.
-fn prompt_card_pin(
+pub(crate) fn prompt_card_pin(
     card_ident: &str,
     key_info: &wecanencrypt::KeyInfo,
 ) -> Result<Zeroizing<String>> {
@@ -158,7 +161,7 @@ fn prompt_card_pin(
 ///
 /// Returns `Zeroizing<String>` so the secret is wiped from memory when
 /// the value is dropped — never converted to a plain `String`.
-fn prompt_key_passphrase(key_info: &wecanencrypt::KeyInfo) -> Result<Zeroizing<String>> {
+pub(crate) fn prompt_key_passphrase(key_info: &wecanencrypt::KeyInfo) -> Result<Zeroizing<String>> {
     let desc = format!("Enter passphrase for key {}", primary_uid(key_info));
     pinentry::get_passphrase(&desc, "Passphrase", Some(&key_info.fingerprint))
 }
@@ -176,4 +179,16 @@ fn primary_uid(key_info: &wecanencrypt::KeyInfo) -> &str {
         .or_else(|| key_info.user_ids.iter().find(|u| !u.revoked))
         .map(|u| u.value.as_str())
         .unwrap_or(&key_info.fingerprint)
+}
+
+enum SecretKind {
+    Pin,
+    Passphrase,
+}
+
+fn backend_secret_kind(backend: &SignBackend) -> SecretKind {
+    match backend {
+        SignBackend::Card => SecretKind::Pin,
+        SignBackend::Software => SecretKind::Passphrase,
+    }
 }

--- a/src/gpg/verify.rs
+++ b/src/gpg/verify.rs
@@ -30,12 +30,12 @@ pub fn verify(
     data.read_to_end(&mut buffer)
         .context("Failed to read data from stdin")?;
 
-    let sig_bytes = std::fs::read(sig_path)
-        .context(format!("Failed to read signature file {:?}", sig_path))?;
+    let sig_bytes =
+        std::fs::read(sig_path).context(format!("Failed to read signature file {:?}", sig_path))?;
 
     let keystore = store::open_keystore(keystore_path)?;
-    let outcome = verify_detached(&keystore, &buffer, &sig_bytes)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let outcome =
+        verify_detached(&keystore, &buffer, &sig_bytes).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     match outcome {
         VerifyOutcome::UnknownKey { key_id } => {
@@ -90,7 +90,11 @@ pub fn verify(
             } else {
                 writeln!(out, "\n[GNUPG:] GOODSIG {}", verifier_key_id)?;
             }
-            writeln!(out, "[GNUPG:] VALIDSIG {}", verifier_fingerprint.to_uppercase())?;
+            writeln!(
+                out,
+                "[GNUPG:] VALIDSIG {}",
+                verifier_fingerprint.to_uppercase()
+            )?;
             // %G? = "G" requires TRUST_FULLY or TRUST_ULTIMATE; without it
             // git's %G? would be "U" (untrusted) and bump-tag rejects that.
             write!(out, "[GNUPG:] TRUST_FULLY 0 pgp")?;

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -16,7 +16,11 @@ use crate::store;
 /// substitution. Each stream may contain multiple keys concatenated
 /// (the default `gpg --export` shape) and every key in the stream is
 /// imported or merged.
-pub fn cmd_import(paths: &[PathBuf], recursive: bool, keystore_path: Option<&PathBuf>) -> Result<()> {
+pub fn cmd_import(
+    paths: &[PathBuf],
+    recursive: bool,
+    keystore_path: Option<&PathBuf>,
+) -> Result<()> {
     log::debug!(
         "cmd_import: paths={} recursive={} keystore_path={:?}",
         paths.len(),
@@ -43,7 +47,14 @@ pub fn cmd_import(paths: &[PathBuf], recursive: bool, keystore_path: Option<&Pat
                 path.is_dir()
             );
             if path.is_dir() {
-                import_dir(&keystore, path, recursive, &mut imported, &mut updated, &mut failed)?;
+                import_dir(
+                    &keystore,
+                    path,
+                    recursive,
+                    &mut imported,
+                    &mut updated,
+                    &mut failed,
+                )?;
             } else {
                 import_file(&keystore, path, &mut imported, &mut updated, &mut failed);
             }
@@ -52,9 +63,14 @@ pub fn cmd_import(paths: &[PathBuf], recursive: bool, keystore_path: Option<&Pat
 
     log::debug!(
         "cmd_import: done imported={} updated={} failed={}",
-        imported, updated, failed,
+        imported,
+        updated,
+        failed,
     );
-    println!("Imported {} new, {} updated, {} failed.", imported, updated, failed);
+    println!(
+        "Imported {} new, {} updated, {} failed.",
+        imported, updated, failed
+    );
     Ok(())
 }
 
@@ -89,8 +105,7 @@ fn import_dir(
     failed: &mut u32,
 ) -> Result<()> {
     log::debug!("import_dir: scanning {:?} recursive={}", dir, recursive);
-    let entries = std::fs::read_dir(dir)
-        .context(format!("Failed to read directory {:?}", dir))?;
+    let entries = std::fs::read_dir(dir).context(format!("Failed to read directory {:?}", dir))?;
 
     for entry in entries {
         let entry = entry?;
@@ -156,7 +171,11 @@ fn import_blob(
     let iter = match PublicOrSecret::from_reader_many(cursor) {
         Ok((iter, _headers)) => iter,
         Err(e) => {
-            log::error!("import_blob: parse_many failed for {}: {:#}", source_label, e);
+            log::error!(
+                "import_blob: parse_many failed for {}: {:#}",
+                source_label,
+                e
+            );
             eprintln!("Failed to parse keys from {}: {:#}", source_label, e);
             *failed += 1;
             return;
@@ -184,7 +203,14 @@ fn import_blob(
             continue;
         }
 
-        import_one_key(keystore, &key_bytes, source_label, imported, updated, failed);
+        import_one_key(
+            keystore,
+            &key_bytes,
+            source_label,
+            imported,
+            updated,
+            failed,
+        );
     }
 
     if !any_key {
@@ -235,12 +261,21 @@ fn import_one_key(
                     .unwrap_or("");
                 match merge_and_reimport(keystore, &key_info.fingerprint, data) {
                     Ok(true) => {
-                        log::info!("import_one_key: merged fp={} (changed)", key_info.fingerprint);
-                        println!("Updated {} ({}) — merged new signatures", key_info.fingerprint, uid);
+                        log::info!(
+                            "import_one_key: merged fp={} (changed)",
+                            key_info.fingerprint
+                        );
+                        println!(
+                            "Updated {} ({}) — merged new signatures",
+                            key_info.fingerprint, uid
+                        );
                         *updated += 1;
                     }
                     Ok(false) => {
-                        log::info!("import_one_key: merged fp={} (no change)", key_info.fingerprint);
+                        log::info!(
+                            "import_one_key: merged fp={} (no change)",
+                            key_info.fingerprint
+                        );
                         println!("Unchanged {} ({}) — no new data", key_info.fingerprint, uid);
                         *updated += 1;
                     }
@@ -273,7 +308,11 @@ fn import_one_key(
             *imported += 1;
         }
         Err(e) => {
-            log::error!("import_one_key: import_key failed for {}: {:#}", source_label, e);
+            log::error!(
+                "import_one_key: import_key failed for {}: {:#}",
+                source_label,
+                e
+            );
             eprintln!("Failed to import key from {}: {:#}", source_label, e);
             *failed += 1;
         }
@@ -288,8 +327,7 @@ fn merge_and_reimport(
     new_data: &[u8],
 ) -> Result<bool> {
     let existing = keystore.export_key(fingerprint)?;
-    let merged = wecanencrypt::merge_keys(&existing, new_data)
-        .context("Key merge failed")?;
+    let merged = wecanencrypt::merge_keys(&existing, new_data).context("Key merge failed")?;
 
     // Re-import the merged key (INSERT OR REPLACE updates the row)
     keystore.import_key(&merged)?;
@@ -315,7 +353,8 @@ pub fn cmd_export(
         let cursor = std::io::Cursor::new(&raw);
         let data = if let Ok((pk, _)) = pgp::composed::SignedPublicKey::from_armor_single(cursor) {
             let mut buf = Vec::new();
-            pk.to_writer(&mut buf).context("Failed to serialize as binary")?;
+            pk.to_writer(&mut buf)
+                .context("Failed to serialize as binary")?;
             buf
         } else {
             raw // Already binary
@@ -360,8 +399,7 @@ pub fn cmd_info(key_id: &str, keystore_path: Option<&PathBuf>) -> Result<()> {
 /// `--info`. Accepts both armored and binary, and both public and
 /// secret key files. Never touches the keystore.
 pub fn cmd_desc(path: &Path) -> Result<()> {
-    let key_data =
-        std::fs::read(path).with_context(|| format!("Failed to read {:?}", path))?;
+    let key_data = std::fs::read(path).with_context(|| format!("Failed to read {:?}", path))?;
     let key_info = wecanencrypt::parse_key_bytes(&key_data, false)
         .with_context(|| format!("Failed to parse key from {:?}", path))?;
     print_key_info(&key_data, &key_info);
@@ -394,10 +432,7 @@ fn print_key_info(key_data: &[u8], key_info: &wecanencrypt::KeyInfo) {
         primary_algo,
         primary_caps.join(", ")
     );
-    println!(
-        "     Created:  {}",
-        key_info.creation_time.format(time_fmt)
-    );
+    println!("     Created:  {}", key_info.creation_time.format(time_fmt));
     if let Some(ref exp) = key_info.expiration_time {
         println!("     Expires:  {}", exp.format(time_fmt));
     } else {
@@ -440,10 +475,7 @@ fn print_key_info(key_data: &[u8], key_info: &wecanencrypt::KeyInfo) {
                 .unwrap_or_default();
             println!(
                 "       {}  {}  [{}]{}",
-                sk.fingerprint,
-                algo,
-                sk.key_type,
-                revoked
+                sk.fingerprint, algo, sk.key_type, revoked
             );
             println!(
                 "                 Created:  {}{}",
@@ -476,7 +508,11 @@ pub fn cmd_delete(key_id: &str, force: bool, keystore_path: Option<&PathBuf>) ->
     if !force {
         eprint!(
             "Delete {} {} ({})? [y/N] ",
-            if key_info.is_secret { "SECRET key" } else { "public key" },
+            if key_info.is_secret {
+                "SECRET key"
+            } else {
+                "public key"
+            },
             key_info.fingerprint,
             uid
         );
@@ -568,7 +604,10 @@ pub fn cmd_fetch(email: &str, dry_run: bool, keystore_path: Option<&PathBuf>) ->
 
     if already_exists {
         match merge_and_reimport(&keystore, &key_info.fingerprint, &key_data) {
-            Ok(true) => println!("Updated {} ({}) — merged new signatures", key_info.fingerprint, uid),
+            Ok(true) => println!(
+                "Updated {} ({}) — merged new signatures",
+                key_info.fingerprint, uid
+            ),
             Ok(false) => println!("Unchanged {} ({}) — no new data", key_info.fingerprint, uid),
             Err(e) => anyhow::bail!("Merge failed: {}", e),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,15 @@
 pub mod agent;
+pub mod cli;
 pub mod gpg;
 pub mod keystore;
+pub mod list_cards;
 pub mod pinentry;
+pub mod sign_cmd;
 pub mod ssh;
 pub mod store;
-pub mod list_cards;
 #[cfg(feature = "experimental")]
 pub mod upload_card;
+pub mod verify_cmd;
 
 /// In-memory credential cache (passphrases and card PINs).
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
 mod cli;
 
+#[cfg(feature = "experimental")]
+mod upload_card {
+    pub use tumpa_cli::upload_card::*;
+}
+
 use std::io::stdout;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-#[cfg(feature = "experimental")]
-use tumpa_cli::upload_card;
 use tumpa_cli::{keystore, pinentry, sign_cmd, ssh, store, verify_cmd};
 
 use cli::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ use std::io::stdout;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use tumpa_cli::{keystore, pinentry, ssh, store};
 #[cfg(feature = "experimental")]
 use tumpa_cli::upload_card;
+use tumpa_cli::{keystore, pinentry, sign_cmd, ssh, store, verify_cmd};
 
 use cli::*;
 
@@ -16,6 +16,8 @@ fn main() {
     let args = Args::parse();
     let keystore_path = args.keystore.clone();
 
+    let mut verify_exit_code: Option<i32> = None;
+
     let res = match Mode::try_from(args) {
         Ok(Mode::ListKeys) => list_keys(keystore_path.as_ref()),
         Ok(Mode::Agent {
@@ -24,7 +26,12 @@ fn main() {
             cache_ttl,
         }) => {
             let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-            rt.block_on(tumpa_cli::agent::run_agent(ssh, ssh_host, cache_ttl, keystore_path))
+            rt.block_on(tumpa_cli::agent::run_agent(
+                ssh,
+                ssh_host,
+                cache_ttl,
+                keystore_path,
+            ))
         }
         Ok(Mode::SshAgent { host }) => {
             let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
@@ -42,7 +49,13 @@ fn main() {
             armor,
             binary,
             output,
-        }) => keystore::cmd_export(&key_id, armor, binary, output.as_ref(), keystore_path.as_ref()),
+        }) => keystore::cmd_export(
+            &key_id,
+            armor,
+            binary,
+            output.as_ref(),
+            keystore_path.as_ref(),
+        ),
         Ok(Mode::Info { key_id }) => keystore::cmd_info(&key_id, keystore_path.as_ref()),
         Ok(Mode::Desc { path }) => keystore::cmd_desc(&path),
         Ok(Mode::Delete { key_id, force }) => {
@@ -82,16 +95,55 @@ fn main() {
         Ok(Mode::ShowSocket { ssh }) => {
             if ssh {
                 match tumpa_cli::agent::default_ssh_socket_path() {
-                    Ok(path) => { println!("{}", path); Ok(()) }
+                    Ok(path) => {
+                        println!("{}", path);
+                        Ok(())
+                    }
                     Err(e) => Err(e),
                 }
             } else {
                 match tumpa_cli::agent::default_socket_path() {
-                    Ok(path) => { println!("{}", path.display()); Ok(()) }
+                    Ok(path) => {
+                        println!("{}", path.display());
+                        Ok(())
+                    }
                     Err(e) => Err(e),
                 }
             }
         }
+        Ok(Mode::Sign {
+            input,
+            with_key,
+            binary,
+            output,
+        }) => sign_cmd::cmd_sign(
+            &input,
+            &with_key,
+            binary,
+            output.as_ref(),
+            keystore_path.as_ref(),
+        ),
+        Ok(Mode::SignInline {
+            input,
+            with_key,
+            output,
+        }) => sign_cmd::cmd_sign_inline(&input, &with_key, output.as_ref(), keystore_path.as_ref()),
+        Ok(Mode::Verify {
+            input,
+            signature,
+            with_key_file,
+        }) => match verify_cmd::cmd_verify(
+            &input,
+            signature.as_ref(),
+            with_key_file.as_ref(),
+            keystore_path.as_ref(),
+        ) {
+            Ok(exit) => {
+                verify_exit_code = Some(exit.code());
+                Ok(())
+            }
+            Err(e) => Err(e),
+        },
         Ok(Mode::None) => {
             print_help();
             Ok(())
@@ -106,6 +158,12 @@ fn main() {
         eprintln!("Error: {e:#}");
         std::process::exit(1);
     }
+
+    if let Some(code) = verify_exit_code {
+        if code != 0 {
+            std::process::exit(code);
+        }
+    }
 }
 
 fn print_help() {
@@ -115,7 +173,7 @@ fn print_help() {
         .unwrap_or_else(|| "tcli".to_string());
 
     eprintln!(
-                "tcli - key management and SSH agent backed by tumpa keystore
+        "tcli - key management and SSH agent backed by tumpa keystore
 
 For git signing and pass integration, use `tclig` as the GPG drop-in:
 
@@ -194,7 +252,10 @@ fn card_status() -> anyhow::Result<()> {
         let info = wecanencrypt::card::get_card_details(Some(&card_summary.ident))
             .map_err(|e| anyhow::anyhow!("Failed to read card {}: {}", card_summary.ident, e))?;
 
-        println!("Manufacturer .....: {}", info.manufacturer_name.as_deref().unwrap_or("Unknown"));
+        println!(
+            "Manufacturer .....: {}",
+            info.manufacturer_name.as_deref().unwrap_or("Unknown")
+        );
         println!("Serial number ....: {}", info.serial_number);
 
         if let Some(ref name) = info.cardholder_name {
@@ -217,9 +278,7 @@ fn card_status() -> anyhow::Result<()> {
         println!("Signature counter : {}", info.signature_counter);
         println!(
             "PIN retry counter : {} {} {}",
-            info.pin_retry_counter,
-            info.reset_code_retry_counter,
-            info.admin_pin_retry_counter
+            info.pin_retry_counter, info.reset_code_retry_counter, info.admin_pin_retry_counter
         );
     }
 
@@ -237,11 +296,7 @@ fn print_card_key(label: &str, fingerprint: &Option<String>) {
                 .map(|i| &fp_upper[i..(i + 4).min(fp_upper.len())])
                 .collect();
             let formatted = if groups.len() >= 10 {
-                format!(
-                    "{}  {}",
-                    groups[..5].join(" "),
-                    groups[5..].join(" ")
-                )
+                format!("{}  {}", groups[..5].join(" "), groups[5..].join(" "))
             } else {
                 groups.join(" ")
             };

--- a/src/pinentry.rs
+++ b/src/pinentry.rs
@@ -8,6 +8,12 @@ use zeroize::Zeroizing;
 
 use crate::agent;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CacheSlot {
+    Pin,
+    Passphrase,
+}
+
 /// Get a passphrase or PIN via the pinentry program.
 ///
 /// Acquisition order:
@@ -31,12 +37,14 @@ pub fn get_passphrase(
     cache_key: Option<&str>,
 ) -> Result<Zeroizing<String>> {
     let allow_agent_cache = should_use_agent_cache(prompt);
+    let cache_slot = cache_slot_for_prompt(prompt);
 
     // 1. Check agent cache for user PIN/passphrase prompts only.
     // Admin PIN must not share the generic fingerprint cache key.
     if allow_agent_cache {
-        if let Some(key) = cache_key {
-            if let Some(pass) = try_agent_get(key) {
+        if let (Some(key), Some(slot)) = (cache_key, cache_slot) {
+            let namespaced_key = cache_key_for_slot(key, slot);
+            if let Some(pass) = try_agent_get(&namespaced_key) {
                 log::debug!("Using passphrase from agent cache");
                 return Ok(pass);
             }
@@ -76,12 +84,40 @@ fn should_use_agent_cache(prompt: &str) -> bool {
     !prompt.eq_ignore_ascii_case("Admin PIN")
 }
 
+fn cache_slot_for_prompt(prompt: &str) -> Option<CacheSlot> {
+    if prompt.eq_ignore_ascii_case("Admin PIN") {
+        None
+    } else if prompt.eq_ignore_ascii_case("PIN") {
+        Some(CacheSlot::Pin)
+    } else {
+        Some(CacheSlot::Passphrase)
+    }
+}
+
+fn cache_key_for_slot(fingerprint: &str, slot: CacheSlot) -> String {
+    match slot {
+        CacheSlot::Pin => format!("pin:{fingerprint}"),
+        CacheSlot::Passphrase => format!("passphrase:{fingerprint}"),
+    }
+}
+
+pub fn cache_pin(fingerprint: &str, pin: &Zeroizing<String>) {
+    try_agent_put(&cache_key_for_slot(fingerprint, CacheSlot::Pin), pin);
+}
+
 /// Store a passphrase / PIN in the running tumpa agent's cache.
 ///
 /// Call this only **after** the value has been confirmed correct by a
 /// successful sign or decrypt. Silent no-op if no agent is running.
 pub fn cache_passphrase(fingerprint: &str, passphrase: &Zeroizing<String>) {
-    try_agent_put(fingerprint, passphrase);
+    try_agent_put(
+        &cache_key_for_slot(fingerprint, CacheSlot::Passphrase),
+        passphrase,
+    );
+}
+
+pub fn clear_cached_pin(fingerprint: &str) {
+    try_agent_clear(&cache_key_for_slot(fingerprint, CacheSlot::Pin));
 }
 
 /// Drop a cached passphrase / PIN from the running tumpa agent.
@@ -90,7 +126,12 @@ pub fn cache_passphrase(fingerprint: &str, passphrase: &Zeroizing<String>) {
 /// stale (or freshly-typed-but-wrong) value is never reused on the
 /// next request. Silent no-op if no agent is running.
 pub fn clear_cached_passphrase(fingerprint: &str) {
-    try_agent_clear(fingerprint);
+    try_agent_clear(&cache_key_for_slot(fingerprint, CacheSlot::Passphrase));
+}
+
+pub fn clear_all_cached_secrets(fingerprint: &str) {
+    clear_cached_pin(fingerprint);
+    clear_cached_passphrase(fingerprint);
 }
 
 /// Try to get a cached passphrase from the agent.
@@ -129,7 +170,6 @@ fn try_agent_put(fingerprint: &str, passphrase: &Zeroizing<String>) {
 }
 
 fn try_agent_put_at_path(socket_path: &Path, fingerprint: &str, passphrase: &Zeroizing<String>) {
-
     let mut stream = match UnixStream::connect(socket_path) {
         Ok(s) => s,
         Err(_) => return,
@@ -164,7 +204,6 @@ fn try_agent_clear(fingerprint: &str) {
 }
 
 fn try_agent_clear_at_path(socket_path: &Path, fingerprint: &str) {
-
     let mut stream = match UnixStream::connect(socket_path) {
         Ok(s) => s,
         Err(_) => return,
@@ -225,7 +264,11 @@ pub fn resolve_pinentry() -> Option<(String, PathBuf)> {
 fn which_on_path(name: &str) -> Option<PathBuf> {
     let p = Path::new(name);
     if p.is_absolute() {
-        return if p.is_file() { Some(p.to_path_buf()) } else { None };
+        return if p.is_file() {
+            Some(p.to_path_buf())
+        } else {
+            None
+        };
     }
     let path_env = std::env::var_os("PATH")?;
     for dir in std::env::split_paths(&path_env) {
@@ -302,8 +345,14 @@ fn try_pinentry_with(
         Err(_) => return Ok(None),
     };
 
-    let mut stdin = child.stdin.take().context("Failed to open pinentry stdin")?;
-    let stdout = child.stdout.take().context("Failed to open pinentry stdout")?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .context("Failed to open pinentry stdin")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("Failed to open pinentry stdout")?;
     let mut reader = BufReader::new(stdout);
 
     // Read the greeting
@@ -485,7 +534,7 @@ mod cache_helper_tests {
 
 #[cfg(test)]
 mod get_passphrase_policy_tests {
-    use super::should_use_agent_cache;
+    use super::{cache_key_for_slot, cache_slot_for_prompt, should_use_agent_cache, CacheSlot};
 
     #[test]
     fn admin_pin_skips_agent_cache() {
@@ -497,5 +546,19 @@ mod get_passphrase_policy_tests {
     fn user_pin_and_passphrase_still_use_agent_cache() {
         assert!(should_use_agent_cache("PIN"));
         assert!(should_use_agent_cache("Passphrase"));
+    }
+
+    #[test]
+    fn pin_and_passphrase_use_distinct_cache_slots() {
+        assert_eq!(cache_slot_for_prompt("PIN"), Some(CacheSlot::Pin));
+        assert_eq!(
+            cache_slot_for_prompt("Passphrase"),
+            Some(CacheSlot::Passphrase)
+        );
+        assert_eq!(cache_key_for_slot("ABCDEF", CacheSlot::Pin), "pin:ABCDEF");
+        assert_eq!(
+            cache_key_for_slot("ABCDEF", CacheSlot::Passphrase),
+            "passphrase:ABCDEF"
+        );
     }
 }

--- a/src/pinentry.rs
+++ b/src/pinentry.rs
@@ -105,7 +105,7 @@ pub fn cache_pin(fingerprint: &str, pin: &Zeroizing<String>) {
     try_agent_put(&cache_key_for_slot(fingerprint, CacheSlot::Pin), pin);
 }
 
-/// Store a passphrase / PIN in the running tumpa agent's cache.
+/// Store a passphrase in the running tumpa agent's cache.
 ///
 /// Call this only **after** the value has been confirmed correct by a
 /// successful sign or decrypt. Silent no-op if no agent is running.
@@ -120,7 +120,7 @@ pub fn clear_cached_pin(fingerprint: &str) {
     try_agent_clear(&cache_key_for_slot(fingerprint, CacheSlot::Pin));
 }
 
-/// Drop a cached passphrase / PIN from the running tumpa agent.
+/// Drop a cached passphrase from the running tumpa agent.
 ///
 /// Call this whenever a sign or decrypt operation fails, to ensure a
 /// stale (or freshly-typed-but-wrong) value is never reused on the

--- a/src/sign_cmd.rs
+++ b/src/sign_cmd.rs
@@ -1,0 +1,253 @@
+//! `tcli --sign` and `tcli --sign-inline` implementations.
+//!
+//! Human-shape sign commands. The GPG-shape sign used by `tclig` lives
+//! in `gpg::sign` and stays unchanged.
+//!
+//! ## Output rules
+//!
+//! - `--sign FILE`: default output is `<FILE>.asc` (ASCII armored).
+//!   `--binary` switches the default to `<FILE>.sig` (binary).
+//! - `--sign-inline FILE`: default output is `<FILE>.asc` (cleartext
+//!   `-----BEGIN PGP SIGNED MESSAGE-----` form).
+//! - `-o`/`--output` overrides the destination. `-` writes to stdout.
+//! - `FILE = -` reads from stdin (caller must also pass `-o`).
+//!
+//! Card-first dispatch (for detached) is handled by `libtumpa::sign`.
+//! Cleartext signing is software-only — card-only keys are rejected.
+
+use std::cell::RefCell;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use zeroize::Zeroizing;
+
+use libtumpa::sign::{
+    dearmor_detached_signature, sign_cleartext as libtumpa_sign_cleartext,
+    sign_detached as libtumpa_sign_detached, Secret, SecretRequest, SignBackend,
+};
+use libtumpa::{Passphrase, Pin};
+
+use crate::cli::is_stdio;
+use crate::gpg::sign::{prompt_card_pin, prompt_key_passphrase};
+use crate::pinentry;
+use crate::store;
+
+/// `tcli --sign FILE --with-key VALUE [--binary] [-o OUT]`.
+pub fn cmd_sign(
+    input: &Path,
+    with_key: &str,
+    binary: bool,
+    output: Option<&PathBuf>,
+    keystore_path: Option<&PathBuf>,
+) -> Result<()> {
+    let data = read_input(input)?;
+    let keystore = store::open_keystore(keystore_path)?;
+    let (key_data, key_info) = store::resolve_signer(&keystore, with_key)?;
+    store::ensure_key_usable_for_signing(&key_info)?;
+
+    let card_ident_used: RefCell<Option<String>> = RefCell::new(None);
+    let last_secret: RefCell<Option<Zeroizing<String>>> = RefCell::new(None);
+
+    let result = libtumpa_sign_detached(&key_data, &key_info, &data, |req| match req {
+        SecretRequest::CardPin {
+            card_ident,
+            key_info,
+        } => {
+            *card_ident_used.borrow_mut() = Some(card_ident.to_string());
+            let pin: Zeroizing<String> = prompt_card_pin(card_ident, key_info)
+                .map_err(|e| libtumpa::Error::Sign(format!("pinentry: {e}")))?;
+            let pin_bytes: Pin = Zeroizing::new(pin.as_bytes().to_vec());
+            *last_secret.borrow_mut() = Some(pin);
+            Ok(Secret::Pin(pin_bytes))
+        }
+        SecretRequest::KeyPassphrase { key_info } => {
+            let pass: Passphrase = prompt_key_passphrase(key_info)
+                .map_err(|e| libtumpa::Error::Sign(format!("pinentry: {e}")))?;
+            *last_secret.borrow_mut() = Some(pass.clone());
+            Ok(Secret::Passphrase(pass))
+        }
+    });
+
+    let (armored_signature, backend) = match result {
+        Ok(ok) => {
+            if let Some(secret) = last_secret.borrow().as_ref() {
+                match backend_secret_kind(&ok.1) {
+                    SecretKind::Pin => pinentry::cache_pin(&key_info.fingerprint, secret),
+                    SecretKind::Passphrase => {
+                        pinentry::cache_passphrase(&key_info.fingerprint, secret)
+                    }
+                }
+            }
+            ok
+        }
+        Err(e) => {
+            pinentry::clear_all_cached_secrets(&key_info.fingerprint);
+            return Err(anyhow!("{e}"));
+        }
+    };
+
+    let payload: Vec<u8> = if binary {
+        dearmor_detached_signature(armored_signature.as_bytes()).map_err(|e| anyhow!("{e}"))?
+    } else {
+        armored_signature.into_bytes()
+    };
+
+    let dest = sign_destination(input, output, binary, /* inline */ false)?;
+    let dest_label = write_payload(&dest, &payload)?;
+
+    match backend {
+        SignBackend::Card => {
+            let ident = card_ident_used
+                .borrow()
+                .clone()
+                .unwrap_or_else(|| "<unknown>".to_string());
+            eprintln!(
+                "tcli: Signed with card {} key {}",
+                ident, key_info.fingerprint
+            );
+        }
+        SignBackend::Software => {
+            eprintln!("tcli: Signed with software key {}", key_info.fingerprint);
+        }
+    }
+    eprintln!("tcli: Wrote signature to {}", dest_label);
+    Ok(())
+}
+
+/// `tcli --sign-inline FILE --with-key VALUE [-o OUT]`. Software-only.
+pub fn cmd_sign_inline(
+    input: &Path,
+    with_key: &str,
+    output: Option<&PathBuf>,
+    keystore_path: Option<&PathBuf>,
+) -> Result<()> {
+    let data = read_input(input)?;
+    let keystore = store::open_keystore(keystore_path)?;
+    let (key_data, key_info) = store::resolve_signer(&keystore, with_key)?;
+    store::ensure_key_usable_for_signing(&key_info)?;
+
+    let last_secret: RefCell<Option<Zeroizing<String>>> = RefCell::new(None);
+
+    let result = libtumpa_sign_cleartext(&key_data, &key_info, &data, |req| match req {
+        SecretRequest::KeyPassphrase { key_info } => {
+            let pass: Passphrase = prompt_key_passphrase(key_info)
+                .map_err(|e| libtumpa::Error::Sign(format!("pinentry: {e}")))?;
+            *last_secret.borrow_mut() = Some(pass.clone());
+            Ok(Secret::Passphrase(pass))
+        }
+        SecretRequest::CardPin { .. } => Err(libtumpa::Error::Sign(
+            "cleartext (inline) signing is software-only and never requests a card PIN".into(),
+        )),
+    });
+
+    let signed = match result {
+        Ok(bytes) => {
+            if let Some(secret) = last_secret.borrow().as_ref() {
+                pinentry::cache_passphrase(&key_info.fingerprint, secret);
+            }
+            bytes
+        }
+        Err(e) => {
+            pinentry::clear_all_cached_secrets(&key_info.fingerprint);
+            return Err(anyhow!("{e}"));
+        }
+    };
+
+    let dest = sign_destination(
+        input, output, /* binary */ false, /* inline */ true,
+    )?;
+    let dest_label = write_payload(&dest, &signed)?;
+    eprintln!(
+        "tcli: Signed inline with software key {}",
+        key_info.fingerprint
+    );
+    eprintln!("tcli: Wrote signed message to {}", dest_label);
+    Ok(())
+}
+
+/// Resolve the output destination.
+///
+/// Returns one of:
+/// - `Destination::Stdout` if `-o -` (or absent and input is stdin — but
+///   that case is rejected at parse time so we only see the `-o -` form).
+/// - `Destination::Path(p)` otherwise. If `output` is `None`, derives
+///   `<input>.<ext>` based on `binary`/`inline`.
+fn sign_destination(
+    input: &Path,
+    output: Option<&PathBuf>,
+    binary: bool,
+    inline: bool,
+) -> Result<Destination> {
+    if let Some(out) = output {
+        if is_stdio(out) {
+            return Ok(Destination::Stdout);
+        }
+        return Ok(Destination::Path(out.clone()));
+    }
+
+    if is_stdio(input) {
+        // CLI parser should already have rejected this, but keep a hard
+        // safety net.
+        bail!("reading from stdin requires -o/--output");
+    }
+
+    // Derive sibling default. Inline always = .asc. Detached: .asc unless --binary.
+    let ext = if inline || !binary { "asc" } else { "sig" };
+    let mut path = input.to_path_buf();
+    let new_name = match path.file_name() {
+        Some(name) => {
+            let mut n = name.to_os_string();
+            n.push(".");
+            n.push(ext);
+            n
+        }
+        None => bail!("input path has no filename: {}", input.display()),
+    };
+    path.set_file_name(new_name);
+    Ok(Destination::Path(path))
+}
+
+enum Destination {
+    Path(PathBuf),
+    Stdout,
+}
+
+fn write_payload(dest: &Destination, bytes: &[u8]) -> Result<String> {
+    match dest {
+        Destination::Path(p) => {
+            std::fs::write(p, bytes).with_context(|| format!("Failed to write {}", p.display()))?;
+            Ok(p.display().to_string())
+        }
+        Destination::Stdout => {
+            std::io::stdout()
+                .write_all(bytes)
+                .context("Failed to write to stdout")?;
+            Ok("stdout".to_string())
+        }
+    }
+}
+
+fn read_input(input: &Path) -> Result<Vec<u8>> {
+    if is_stdio(input) {
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .context("Failed to read from stdin")?;
+        Ok(buf)
+    } else {
+        std::fs::read(input).with_context(|| format!("Failed to read {}", input.display()))
+    }
+}
+
+enum SecretKind {
+    Pin,
+    Passphrase,
+}
+
+fn backend_secret_kind(backend: &SignBackend) -> SecretKind {
+    match backend {
+        SignBackend::Card => SecretKind::Pin,
+        SignBackend::Software => SecretKind::Passphrase,
+    }
+}

--- a/src/ssh/agent.rs
+++ b/src/ssh/agent.rs
@@ -55,10 +55,7 @@ impl TumpaBackend {
 
     /// Create a backend with a shared credential cache.
     /// Used when the SSH agent runs alongside the GPG cache agent.
-    pub fn with_cache(
-        keystore_path: Option<PathBuf>,
-        cache: Arc<Mutex<CredentialCache>>,
-    ) -> Self {
+    pub fn with_cache(keystore_path: Option<PathBuf>, cache: Arc<Mutex<CredentialCache>>) -> Self {
         let backend = Self {
             keystore_path,
             cache,
@@ -232,7 +229,10 @@ impl Session for TumpaBackend {
 
         // Look up card_ident from cache (zero card I/O)
         let card_match = {
-            let card_ids = self.card_identities.lock().map_err(|_| AgentError::Failure)?;
+            let card_ids = self
+                .card_identities
+                .lock()
+                .map_err(|_| AgentError::Failure)?;
             card_ids
                 .iter()
                 .find(|id| id.ssh_key_data == request.pubkey)
@@ -253,7 +253,10 @@ impl Session for TumpaBackend {
         // Re-enumerate and try again.
         self.refresh_card_identities();
         let card_match = {
-            let card_ids = self.card_identities.lock().map_err(|_| AgentError::Failure)?;
+            let card_ids = self
+                .card_identities
+                .lock()
+                .map_err(|_| AgentError::Failure)?;
             card_ids
                 .iter()
                 .find(|id| id.ssh_key_data == request.pubkey)
@@ -525,19 +528,15 @@ impl TumpaBackend {
 
         let sign_data = prepare_sign_data(request).ok_or(AgentError::Failure)?;
 
-        let result = wecanencrypt::ssh_sign_raw(
-            key_data,
-            &sign_data.data,
-            &passphrase,
-            sign_data.hash_alg,
-        )
-        .map_err(|e| {
-            log::error!("SSH signing failed: {}", e);
-            if let Ok(mut cache) = self.cache.lock() {
-                cache.remove(fingerprint);
-            }
-            AgentError::Failure
-        })?;
+        let result =
+            wecanencrypt::ssh_sign_raw(key_data, &sign_data.data, &passphrase, sign_data.hash_alg)
+                .map_err(|e| {
+                    log::error!("SSH signing failed: {}", e);
+                    if let Ok(mut cache) = self.cache.lock() {
+                        cache.remove(fingerprint);
+                    }
+                    AgentError::Failure
+                })?;
 
         match result {
             wecanencrypt::SshSignResult::Ed25519(sig_bytes) => {
@@ -683,11 +682,9 @@ fn parse_ssh_pubkey_line(line: &str) -> Result<KeyData, String> {
 /// in the logs instead of requiring a post-mortem.
 fn log_pinentry_at_startup() {
     match pinentry::resolve_pinentry() {
-        Some((name, path)) => log::info!(
-            "pinentry: using {} (resolved to {})",
-            name,
-            path.display()
-        ),
+        Some((name, path)) => {
+            log::info!("pinentry: using {} (resolved to {})", name, path.display())
+        }
         None => log::warn!(
             "pinentry: no candidate resolved on PATH ({:?}) — \
              passphrase prompts will fall back to STDIN. \

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -47,7 +47,9 @@ pub async fn run_agent(host: &str, keystore_path: Option<PathBuf>) -> Result<()>
     // Restore umask
     #[cfg(unix)]
     if let Some(old) = _old_umask {
-        unsafe { libc::umask(old); }
+        unsafe {
+            libc::umask(old);
+        }
     }
 
     result.map_err(|e| anyhow::anyhow!("SSH agent error: {:?}", e))?;
@@ -84,7 +86,9 @@ pub async fn run_agent_with_cache(
 
     #[cfg(unix)]
     if let Some(old) = _old_umask {
-        unsafe { libc::umask(old); }
+        unsafe {
+            libc::umask(old);
+        }
     }
 
     result.map_err(|e| anyhow::anyhow!("SSH agent error: {:?}", e))?;

--- a/src/tclig/cli.rs
+++ b/src/tclig/cli.rs
@@ -14,7 +14,6 @@ use clap_complete::Shell;
 #[clap(name = "tclig", version)]
 pub struct Args {
     // --- Signing ---
-
     /// Create a detached signature.
     #[clap(long, short = 'b')]
     pub detach_sign: bool,
@@ -28,13 +27,11 @@ pub struct Args {
     pub local_user: Option<String>,
 
     // --- Verification ---
-
     /// Verify a detached signature.
     #[clap(long, value_names = ["SIGNATURE_FILE"])]
     pub verify: Option<PathBuf>,
 
     // --- Encryption ---
-
     /// Encrypt mode.
     #[clap(short = 'e', long)]
     pub encrypt: bool,
@@ -44,13 +41,11 @@ pub struct Args {
     pub recipients: Vec<String>,
 
     // --- Decryption ---
-
     /// Decrypt mode.
     #[clap(short = 'd', long)]
     pub decrypt: bool,
 
     // --- Output ---
-
     /// Output ASCII-armored data.
     #[clap(long, short = 'a')]
     pub armor: bool,
@@ -60,7 +55,6 @@ pub struct Args {
     pub output: Option<PathBuf>,
 
     // --- Key listing ---
-
     /// List keys in the tumpa keystore (GPG colon format).
     #[clap(long)]
     pub list_keys: bool,
@@ -78,24 +72,20 @@ pub struct Args {
     pub list_only: bool,
 
     // --- Positional ---
-
     /// Positional arguments: input files, or "-" for stdin in verify mode.
     pub input_files: Vec<String>,
 
     // --- Keystore ---
-
     /// Path to tumpa keystore database. Defaults to ~/.tumpa/keys.db.
     #[clap(long, env = "TUMPA_KEYSTORE")]
     pub keystore: Option<PathBuf>,
 
     // --- Shell completions ---
-
     /// Generate shell completions and print to stdout.
     #[clap(long, value_name = "SHELL", value_enum)]
     pub completions: Option<Shell>,
 
     // --- GPG compatibility flags (accepted, ignored) ---
-
     #[clap(long, hide = true)]
     pub keyid_format: Option<String>,
 

--- a/src/tpass/cli.rs
+++ b/src/tpass/cli.rs
@@ -6,7 +6,7 @@ use clap_complete::Shell;
     name = "tpass",
     about = "tpass - password store backed by tumpa keystore",
     version,
-    disable_help_subcommand = true,
+    disable_help_subcommand = true
 )]
 pub struct Args {
     #[clap(subcommand)]

--- a/src/tpass/commands/cp.rs
+++ b/src/tpass/commands/cp.rs
@@ -23,10 +23,10 @@ pub fn cmd_cp(old_path: &str, new_path: &str, force: bool) -> Result<()> {
     }
 
     // Check for overwrite
-    if !force && new_full.exists()
-        && !yesno(&format!("{} already exists. Overwrite it?", new_path)) {
-            std::process::exit(1);
-        }
+    if !force && new_full.exists() && !yesno(&format!("{} already exists. Overwrite it?", new_path))
+    {
+        std::process::exit(1);
+    }
 
     // Copy
     if old_full.is_dir() {
@@ -87,7 +87,10 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()
         let dst_path = dst.join(entry.file_name());
         let metadata = std::fs::symlink_metadata(&src_path)?;
         if metadata.file_type().is_symlink() {
-            anyhow::bail!("Error: Refusing to copy symlinked path {}.", src_path.display());
+            anyhow::bail!(
+                "Error: Refusing to copy symlinked path {}.",
+                src_path.display()
+            );
         }
         if metadata.is_dir() {
             copy_dir_recursive(&src_path, &dst_path)?;

--- a/src/tpass/commands/edit.rs
+++ b/src/tpass/commands/edit.rs
@@ -84,12 +84,7 @@ pub fn cmd_edit(path: &str) -> Result<()> {
         let _ = git::git_add_file(
             gd,
             &passfile,
-            &format!(
-                "{} password for {} using {}.",
-                action,
-                path,
-                editor
-            ),
+            &format!("{} password for {} using {}.", action, path, editor),
         );
     }
 
@@ -123,7 +118,11 @@ fn create_secure_tmpdir() -> Result<PathBuf> {
 }
 
 fn create_secure_tmpfile(dir: &Path, path: &str) -> Result<PathBuf> {
-    let tmp_file = dir.join(format!("{}-{}.txt", path.replace('/', "-"), random_suffix()?));
+    let tmp_file = dir.join(format!(
+        "{}-{}.txt",
+        path.replace('/', "-"),
+        random_suffix()?
+    ));
     let mut options = std::fs::OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]

--- a/src/tpass/commands/generate.rs
+++ b/src/tpass/commands/generate.rs
@@ -44,13 +44,16 @@ pub fn cmd_generate(
     let recipients = get_recipients(&prefix, &dir_path)?;
     let git_dir = git::find_git_dir(&passfile, &prefix);
 
-    if !in_place && !force && passfile.exists()
+    if !in_place
+        && !force
+        && passfile.exists()
         && !yesno(&format!(
             "An entry already exists for {}. Overwrite it?",
             path
-        )) {
-            std::process::exit(1);
-        }
+        ))
+    {
+        std::process::exit(1);
+    }
 
     // Generate password using /dev/urandom + tr (matching pass behavior)
     let pass = generate_password(length, &characters)?;
@@ -58,18 +61,11 @@ pub fn cmd_generate(
     if in_place {
         // Replace only the first line of the existing file
         if !passfile.exists() {
-            anyhow::bail!(
-                "Error: {} does not exist. Cannot use --in-place.",
-                path
-            );
+            anyhow::bail!("Error: {} does not exist. Cannot use --in-place.", path);
         }
         let existing = crypto::decrypt_file(&passfile, None)?;
         let existing_str = String::from_utf8_lossy(&existing);
-        let rest: String = existing_str
-            .lines()
-            .skip(1)
-            .collect::<Vec<_>>()
-            .join("\n");
+        let rest: String = existing_str.lines().skip(1).collect::<Vec<_>>().join("\n");
 
         let new_content = if rest.is_empty() {
             format!("{}\n", pass)

--- a/src/tpass/commands/git.rs
+++ b/src/tpass/commands/git.rs
@@ -21,11 +21,7 @@ pub fn cmd_git(args: &[String]) -> Result<()> {
         }
 
         // Add current contents
-        let _ = git::git_add_file(
-            &prefix,
-            &prefix,
-            "Add current contents of password store.",
-        );
+        let _ = git::git_add_file(&prefix, &prefix, "Add current contents of password store.");
 
         // Create .gitattributes
         let gitattributes = prefix.join(".gitattributes");
@@ -61,9 +57,7 @@ pub fn cmd_git(args: &[String]) -> Result<()> {
     } else if let Some(ref gd) = git_dir {
         git::git_run(gd, args)?;
     } else {
-        anyhow::bail!(
-            "Error: the password store is not a git repository. Try \"tpass git init\"."
-        );
+        anyhow::bail!("Error: the password store is not a git repository. Try \"tpass git init\".");
     }
 
     Ok(())

--- a/src/tpass/commands/grep.rs
+++ b/src/tpass/commands/grep.rs
@@ -26,9 +26,7 @@ fn walk_and_grep(
     grep_args: &[String],
     found_any: &mut bool,
 ) -> Result<()> {
-    let mut entries: Vec<_> = std::fs::read_dir(dir)?
-        .filter_map(|e| e.ok())
-        .collect();
+    let mut entries: Vec<_> = std::fs::read_dir(dir)?.filter_map(|e| e.ok()).collect();
     entries.sort_by_key(|e| e.file_name());
 
     for entry in entries {
@@ -82,10 +80,7 @@ fn walk_and_grep(
                             ("", rel.as_str())
                         };
 
-                        println!(
-                            "\x1b[94m{}\x1b[1m{}\x1b[0m:",
-                            dir_part, file_part
-                        );
+                        println!("\x1b[94m{}\x1b[1m{}\x1b[0m:", dir_part, file_part);
                         std::io::stdout().write_all(&output.stdout)?;
                     }
                 }

--- a/src/tpass/commands/init.rs
+++ b/src/tpass/commands/init.rs
@@ -38,8 +38,7 @@ pub fn get_recipients(prefix: &std::path::Path, subpath: &str) -> Result<Vec<Str
 
 /// Read a .gpg-id file, returning the list of GPG IDs.
 fn read_gpg_id_file(path: &std::path::Path) -> Result<Vec<String>> {
-    let content = std::fs::read_to_string(path)
-        .context(format!("Failed to read {:?}", path))?;
+    let content = std::fs::read_to_string(path).context(format!("Failed to read {:?}", path))?;
     let ids: Vec<String> = content
         .lines()
         .map(|line| {
@@ -88,8 +87,10 @@ pub fn reencrypt_path(
 
         // Recompute target key IDs if recipients changed
         if prev_recipients.as_ref() != Some(&recipients) {
-            target_key_ids =
-                Some(crypto::recipient_encryption_key_ids(&recipients, keystore_path)?);
+            target_key_ids = Some(crypto::recipient_encryption_key_ids(
+                &recipients,
+                keystore_path,
+            )?);
             prev_recipients = Some(recipients.clone());
         }
 
@@ -110,11 +111,7 @@ pub fn reencrypt_path(
                 .to_string_lossy()
                 .trim_end_matches(".gpg")
                 .to_string();
-            eprintln!(
-                "{}: reencrypting to {}",
-                display,
-                sorted_target.join(" ")
-            );
+            eprintln!("{}: reencrypting to {}", display, sorted_target.join(" "));
 
             // Decrypt and re-encrypt
             let plaintext = crypto::decrypt_file(&entry_path, keystore_path)?;
@@ -136,10 +133,7 @@ fn walkdir(
     Ok(Box::new(entries.into_iter().map(Ok)))
 }
 
-fn walk_recursive(
-    path: &std::path::Path,
-    entries: &mut Vec<std::fs::DirEntry>,
-) -> Result<()> {
+fn walk_recursive(path: &std::path::Path, entries: &mut Vec<std::fs::DirEntry>) -> Result<()> {
     if !path.is_dir() {
         return Ok(());
     }
@@ -181,7 +175,10 @@ pub fn cmd_init(path: Option<&str>, gpg_ids: &[String]) -> Result<()> {
 
     // Check that if id_path exists, it's a directory
     if !id_path.is_empty() && full_path.exists() && !full_path.is_dir() {
-        anyhow::bail!("Error: {} exists but is not a directory.", full_path.display());
+        anyhow::bail!(
+            "Error: {} exists but is not a directory.",
+            full_path.display()
+        );
     }
 
     let gpg_id_file = full_path.join(".gpg-id");
@@ -341,10 +338,7 @@ pub fn ensure_no_symlink_in_path(path: &Path, prefix: &Path) -> Result<()> {
 }
 
 /// Remove empty parent directories up to (but not including) the stop directory.
-pub fn remove_empty_parents(
-    start: &std::path::Path,
-    stop: &std::path::Path,
-) -> Result<()> {
+pub fn remove_empty_parents(start: &std::path::Path, stop: &std::path::Path) -> Result<()> {
     let mut current = start.to_path_buf();
     while current != stop.to_path_buf() {
         if current.is_dir() {

--- a/src/tpass/commands/insert.rs
+++ b/src/tpass/commands/insert.rs
@@ -15,13 +15,15 @@ pub fn cmd_insert(path: &str, multiline: bool, echo: bool, force: bool) -> Resul
     let passfile = checked_passfile_path(&prefix, path)?;
     let git_dir = git::find_git_dir(&passfile, &prefix);
 
-    if !force && passfile.exists()
+    if !force
+        && passfile.exists()
         && !yesno(&format!(
             "An entry already exists for {}. Overwrite it?",
-        path
-        )) {
-            std::process::exit(1);
-        }
+            path
+        ))
+    {
+        std::process::exit(1);
+    }
 
     // Create parent directories
     if let Some(parent) = passfile.parent() {
@@ -53,8 +55,7 @@ pub fn cmd_insert(path: &str, multiline: bool, echo: bool, force: bool) -> Resul
     } else {
         // No-echo mode: read password twice, confirm match
         let password = rpassword::prompt_password(format!("Enter password for {}: ", path))?;
-        let password_again =
-            rpassword::prompt_password(format!("Retype password for {}: ", path))?;
+        let password_again = rpassword::prompt_password(format!("Retype password for {}: ", path))?;
 
         if password != password_again {
             anyhow::bail!("Error: the entered passwords do not match.");

--- a/src/tpass/commands/mv.rs
+++ b/src/tpass/commands/mv.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 
 use crate::util::{config, git};
 
-use super::init::{check_sneaky_paths, checked_passfile_path, checked_store_path, reencrypt_path, remove_empty_parents};
+use super::init::{
+    check_sneaky_paths, checked_passfile_path, checked_store_path, reencrypt_path,
+    remove_empty_parents,
+};
 use super::insert::yesno;
 
 /// `tpass mv [--force,-f] old-path new-path`
@@ -23,13 +26,10 @@ pub fn cmd_mv(old_path: &str, new_path: &str, force: bool) -> Result<()> {
     }
 
     // Check for overwrite
-    if !force && new_full.exists()
-        && !yesno(&format!(
-            "{} already exists. Overwrite it?",
-            new_path
-        )) {
-            std::process::exit(1);
-        }
+    if !force && new_full.exists() && !yesno(&format!("{} already exists. Overwrite it?", new_path))
+    {
+        std::process::exit(1);
+    }
 
     // Move
     std::fs::rename(&old_full, &new_full)?;

--- a/src/tpass/commands/rm.rs
+++ b/src/tpass/commands/rm.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 
 use crate::util::{config, git};
 
-use super::init::{check_sneaky_paths, checked_passfile_path, checked_store_path, remove_empty_parents};
+use super::init::{
+    check_sneaky_paths, checked_passfile_path, checked_store_path, remove_empty_parents,
+};
 use super::insert::yesno;
 
 /// `tpass rm [--recursive,-r] [--force,-f] pass-name`
@@ -34,20 +36,19 @@ pub fn cmd_rm(path: &str, recursive: bool, force: bool) -> Result<()> {
         anyhow::bail!("Error: {} is not in the password store.", path);
     }
 
-    if !force
-        && !yesno(&format!(
-            "Are you sure you would like to delete {}?",
-            path
-        )) {
-            std::process::exit(1);
-        }
+    if !force && !yesno(&format!("Are you sure you would like to delete {}?", path)) {
+        std::process::exit(1);
+    }
 
     // Remove the file/directory
     if target.is_dir() {
         if recursive {
             std::fs::remove_dir_all(&target)?;
         } else {
-            anyhow::bail!("Error: {} is a directory. Use -r to remove recursively.", path);
+            anyhow::bail!(
+                "Error: {} is a directory. Use -r to remove recursively.",
+                path
+            );
         }
     } else {
         std::fs::remove_file(&target)?;

--- a/src/tpass/commands/show.rs
+++ b/src/tpass/commands/show.rs
@@ -5,7 +5,11 @@ use crate::util::{clip, config, crypto, tree};
 use super::init::{check_sneaky_paths, checked_passfile_path, checked_store_path};
 
 /// `tpass [show] [--clip[=N],-c[N]] [--qrcode[=N],-q[N]] [pass-name]`
-pub fn cmd_show(path: Option<&str>, clip_line: Option<usize>, qrcode_line: Option<usize>) -> Result<()> {
+pub fn cmd_show(
+    path: Option<&str>,
+    clip_line: Option<usize>,
+    qrcode_line: Option<usize>,
+) -> Result<()> {
     let prefix = config::store_dir();
 
     let path = path.unwrap_or("");
@@ -21,10 +25,7 @@ pub fn cmd_show(path: Option<&str>, clip_line: Option<usize>, qrcode_line: Optio
         let content = String::from_utf8_lossy(&plaintext);
 
         if let Some(line_num) = clip_line {
-            let line = content
-                .lines()
-                .nth(line_num - 1)
-                .unwrap_or("");
+            let line = content.lines().nth(line_num - 1).unwrap_or("");
             if line.is_empty() {
                 anyhow::bail!(
                     "There is no password to put on the clipboard at line {}.",
@@ -33,10 +34,7 @@ pub fn cmd_show(path: Option<&str>, clip_line: Option<usize>, qrcode_line: Optio
             }
             clip::clip(line, path)?;
         } else if let Some(line_num) = qrcode_line {
-            let line = content
-                .lines()
-                .nth(line_num - 1)
-                .unwrap_or("");
+            let line = content.lines().nth(line_num - 1).unwrap_or("");
             if line.is_empty() {
                 anyhow::bail!(
                     "There is no password to put on the clipboard at line {}.",
@@ -67,15 +65,43 @@ pub fn cmd_show(path: Option<&str>, clip_line: Option<usize>, qrcode_line: Optio
 fn qrcode(data: &str, name: &str) -> Result<()> {
     use std::process::{Command, Stdio};
 
-    let has_display =
-        std::env::var("DISPLAY").is_ok() || std::env::var("WAYLAND_DISPLAY").is_ok();
+    let has_display = std::env::var("DISPLAY").is_ok() || std::env::var("WAYLAND_DISPLAY").is_ok();
 
     if has_display {
         // Try graphical viewers: feh, gm, display
         for (viewer, args) in &[
-            ("feh", vec!["-x", "--title", &format!("pass: {}", name), "-g", "+200+200", "-"]),
-            ("gm", vec!["display", "-title", &format!("pass: {}", name), "-geometry", "+200+200", "-"]),
-            ("display", vec!["-title", &format!("pass: {}", name), "-geometry", "+200+200", "-"]),
+            (
+                "feh",
+                vec![
+                    "-x",
+                    "--title",
+                    &format!("pass: {}", name),
+                    "-g",
+                    "+200+200",
+                    "-",
+                ],
+            ),
+            (
+                "gm",
+                vec![
+                    "display",
+                    "-title",
+                    &format!("pass: {}", name),
+                    "-geometry",
+                    "+200+200",
+                    "-",
+                ],
+            ),
+            (
+                "display",
+                vec![
+                    "-title",
+                    &format!("pass: {}", name),
+                    "-geometry",
+                    "+200+200",
+                    "-",
+                ],
+            ),
         ] {
             if Command::new("which")
                 .arg(viewer)

--- a/src/tpass/main.rs
+++ b/src/tpass/main.rs
@@ -47,7 +47,10 @@ fn main() {
             Shell::Zsh => include_str!("../../completions/tpass.zsh"),
             Shell::Fish => include_str!("../../completions/tpass.fish"),
             _ => {
-                eprintln!("Completions not available for {:?}. Supported: bash, zsh, fish.", shell);
+                eprintln!(
+                    "Completions not available for {:?}. Supported: bash, zsh, fish.",
+                    shell
+                );
                 std::process::exit(1);
             }
         };
@@ -254,7 +257,10 @@ fn run_extension(path: &std::path::Path, args: &[String]) -> bool {
     std::env::set_var("EXTENSIONS", util::config::extensions_dir());
     std::env::set_var("X_SELECTION", util::config::x_selection());
     std::env::set_var("CLIP_TIME", util::config::clip_time().to_string());
-    std::env::set_var("GENERATED_LENGTH", util::config::generated_length().to_string());
+    std::env::set_var(
+        "GENERATED_LENGTH",
+        util::config::generated_length().to_string(),
+    );
     std::env::set_var("CHARACTER_SET", util::config::character_set());
     std::env::set_var(
         "CHARACTER_SET_NO_SYMBOLS",
@@ -265,9 +271,7 @@ fn run_extension(path: &std::path::Path, args: &[String]) -> bool {
     let mut cmd_args = vec![path.to_string_lossy().to_string()];
     cmd_args.extend(args.iter().cloned());
 
-    let status = std::process::Command::new("bash")
-        .args(&cmd_args)
-        .status();
+    let status = std::process::Command::new("bash").args(&cmd_args).status();
 
     match status {
         Ok(s) => {

--- a/src/tpass/util/clip.rs
+++ b/src/tpass/util/clip.rs
@@ -149,7 +149,11 @@ fn get_clipboard_base64(paste_cmd: &[String]) -> Option<String> {
             child.wait_with_output().ok()
         })?;
 
-    Some(String::from_utf8_lossy(&base64_output.stdout).trim().to_string())
+    Some(
+        String::from_utf8_lossy(&base64_output.stdout)
+            .trim()
+            .to_string(),
+    )
 }
 
 fn shell_escape(s: &str) -> String {

--- a/src/tpass/util/config.rs
+++ b/src/tpass/util/config.rs
@@ -41,19 +41,15 @@ pub fn x_selection() -> String {
 }
 
 pub fn signing_key() -> Option<Vec<String>> {
-    std::env::var("PASSWORD_STORE_SIGNING_KEY").ok().map(|v| {
-        v.split_whitespace()
-            .map(|s| s.to_string())
-            .collect()
-    })
+    std::env::var("PASSWORD_STORE_SIGNING_KEY")
+        .ok()
+        .map(|v| v.split_whitespace().map(|s| s.to_string()).collect())
 }
 
 pub fn store_key() -> Option<Vec<String>> {
-    std::env::var("PASSWORD_STORE_KEY").ok().map(|v| {
-        v.split_whitespace()
-            .map(|s| s.to_string())
-            .collect()
-    })
+    std::env::var("PASSWORD_STORE_KEY")
+        .ok()
+        .map(|v| v.split_whitespace().map(|s| s.to_string()).collect())
 }
 
 pub fn extensions_enabled() -> bool {

--- a/src/tpass/util/crypto.rs
+++ b/src/tpass/util/crypto.rs
@@ -98,11 +98,11 @@ fn try_decrypt_on_card(
 
     match ltd::decrypt_on_card(&card.key_data, ciphertext, &pin_obj, Some(&card.card.ident)) {
         Ok(z) => {
-            pinentry::cache_passphrase(&card.key_info.fingerprint, &pin);
+            pinentry::cache_pin(&card.key_info.fingerprint, &pin);
             Ok(Zeroizing::new(z.to_vec()))
         }
         Err(e) => {
-            pinentry::clear_cached_passphrase(&card.key_info.fingerprint);
+            pinentry::clear_cached_pin(&card.key_info.fingerprint);
             Err(anyhow::anyhow!("{e}")).context("Card decryption failed")
         }
     }

--- a/src/tpass/util/git.rs
+++ b/src/tpass/util/git.rs
@@ -14,7 +14,12 @@ pub fn find_git_dir(path: &Path, prefix: &Path) -> Option<std::path::PathBuf> {
             break;
         }
         let output = Command::new("git")
-            .args(["-C", &current.to_string_lossy(), "rev-parse", "--is-inside-work-tree"])
+            .args([
+                "-C",
+                &current.to_string_lossy(),
+                "rev-parse",
+                "--is-inside-work-tree",
+            ])
             .output()
             .ok()?;
         if output.status.success() {
@@ -37,7 +42,12 @@ pub fn find_git_dir(path: &Path, prefix: &Path) -> Option<std::path::PathBuf> {
 /// Checks pass.signcommits config for -S flag.
 pub fn git_add_file(git_dir: &Path, file: &Path, message: &str) -> Result<()> {
     let status = Command::new("git")
-        .args(["-C", &git_dir.to_string_lossy(), "add", &file.to_string_lossy()])
+        .args([
+            "-C",
+            &git_dir.to_string_lossy(),
+            "add",
+            &file.to_string_lossy(),
+        ])
         .status()
         .context("Failed to run git add")?;
 
@@ -83,11 +93,7 @@ pub fn git_commit(git_dir: &Path, message: &str) -> Result<()> {
         .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "true")
         .unwrap_or(false);
 
-    let mut cmd_args = vec![
-        "-C".to_string(),
-        git_dir_str,
-        "commit".to_string(),
-    ];
+    let mut cmd_args = vec!["-C".to_string(), git_dir_str, "commit".to_string()];
     if sign {
         cmd_args.push("-S".to_string());
     }

--- a/src/upload_card.rs
+++ b/src/upload_card.rs
@@ -78,9 +78,7 @@ pub fn cmd_upload_to_card(
     }
 
     if include_signing && matches!(which, Some(WhichKey::Primary)) {
-        bail!(
-            "`--include-signing` cannot be combined with `--which primary`"
-        );
+        bail!("`--include-signing` cannot be combined with `--which primary`");
     }
 
     // `--include-signing` is the discoverable spelling of "use the
@@ -95,9 +93,7 @@ pub fn cmd_upload_to_card(
     // never passed `--which`.
     let effective_which = if include_signing && which.is_none() {
         let has_signing_subkey = key_info.subkeys.iter().any(|sk| {
-            sk.key_type == KeyType::Signing
-                && !sk.is_revoked
-                && !store::subkey_is_expired(sk)
+            sk.key_type == KeyType::Signing && !sk.is_revoked && !store::subkey_is_expired(sk)
         });
         if !has_signing_subkey {
             bail!(
@@ -210,7 +206,9 @@ fn select_sign_target(
     let signing_subkeys: Vec<_> = key_info
         .subkeys
         .iter()
-        .filter(|sk| sk.key_type == KeyType::Signing && !sk.is_revoked && !store::subkey_is_expired(sk))
+        .filter(|sk| {
+            sk.key_type == KeyType::Signing && !sk.is_revoked && !store::subkey_is_expired(sk)
+        })
         .collect();
 
     match (primary_can_sign, signing_subkeys.len(), which) {

--- a/src/verify_cmd.rs
+++ b/src/verify_cmd.rs
@@ -1,0 +1,200 @@
+//! `tcli --verify` implementation.
+//!
+//! Human-shape verify command. The GPG-shape verify used by `tclig`
+//! lives in `gpg::verify` and stays unchanged.
+//!
+//! Two flavors:
+//! - **Detached**: `--signature SIG_FILE` is set; verify SIG against the
+//!   bytes of FILE.
+//! - **Inline**: no `--signature`; FILE itself is a cleartext-signed
+//!   message (`-----BEGIN PGP SIGNED MESSAGE-----`).
+//!
+//! `--with-key FILE` (optional) verifies against an external public-key
+//! file instead of the keystore.
+//!
+//! Exit codes (returned via [`VerifyExit`]):
+//! - `0` (`Good`) — signature valid.
+//! - `1` (`Bad`) — signature invalid for a known key.
+//! - `2` (`Unknown`) — signer not in keystore, no `--with-key` supplied.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+use libtumpa::verify::{
+    sanitize_uid_for_status as sanitize_uid, verify_detached, verify_inline, VerifyOutcome,
+};
+use wecanencrypt::KeyInfo;
+
+use crate::cli::is_stdio;
+use crate::store;
+
+/// Logical exit-code outcome for `tcli --verify`. main.rs maps these to
+/// process exit codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyExit {
+    Good,
+    Bad,
+    Unknown,
+}
+
+impl VerifyExit {
+    pub fn code(self) -> i32 {
+        match self {
+            Self::Good => 0,
+            Self::Bad => 1,
+            Self::Unknown => 2,
+        }
+    }
+}
+
+/// `tcli --verify FILE [--signature SIG] [--with-key PUB_FILE]`.
+pub fn cmd_verify(
+    input: &Path,
+    signature: Option<&PathBuf>,
+    with_key_file: Option<&PathBuf>,
+    keystore_path: Option<&PathBuf>,
+) -> Result<VerifyExit> {
+    let data = read_input(input)?;
+
+    // External public-key path: do not touch the keystore at all.
+    if let Some(pub_file) = with_key_file {
+        let cert_data = std::fs::read(pub_file)
+            .with_context(|| format!("Failed to read public key file {}", pub_file.display()))?;
+        let cert_info = wecanencrypt::parse_key_bytes(&cert_data, true)
+            .map_err(|e| anyhow!("Failed to parse {}: {e}", pub_file.display()))?;
+
+        return match signature {
+            Some(sig_path) => {
+                let sig_bytes = std::fs::read(sig_path).with_context(|| {
+                    format!("Failed to read signature file {}", sig_path.display())
+                })?;
+                let valid = wecanencrypt::verify_bytes_detached(&cert_data, &data, &sig_bytes)
+                    .map_err(|e| anyhow!("verify_bytes_detached: {e}"))?;
+                report_external(&cert_info, valid);
+                Ok(if valid {
+                    VerifyExit::Good
+                } else {
+                    VerifyExit::Bad
+                })
+            }
+            None => {
+                let valid = wecanencrypt::verify_bytes(&cert_data, &data)
+                    .map_err(|e| anyhow!("verify_bytes: {e}"))?;
+                report_external(&cert_info, valid);
+                Ok(if valid {
+                    VerifyExit::Good
+                } else {
+                    VerifyExit::Bad
+                })
+            }
+        };
+    }
+
+    // Keystore lookup path.
+    let keystore = store::open_keystore(keystore_path)?;
+
+    let outcome = match signature {
+        Some(sig_path) => {
+            let sig_bytes = std::fs::read(sig_path)
+                .with_context(|| format!("Failed to read signature file {}", sig_path.display()))?;
+            verify_detached(&keystore, &data, &sig_bytes).map_err(|e| anyhow!("{e}"))?
+        }
+        None => verify_inline(&keystore, &data).map_err(|e| anyhow!("{e}"))?,
+    };
+
+    Ok(report_outcome(outcome))
+}
+
+/// Print human-readable result and pick the exit category.
+///
+/// `Good`: lists every non-revoked UID (primary first, then `aka …`),
+/// then the verifier fingerprint.
+fn report_outcome(outcome: VerifyOutcome) -> VerifyExit {
+    match outcome {
+        VerifyOutcome::Good {
+            key_info,
+            verifier_fingerprint,
+        } => {
+            print_uids("Good signature from", &key_info);
+            eprintln!(
+                "tcli: Primary key fingerprint: {}",
+                key_info.fingerprint.to_uppercase()
+            );
+            if verifier_fingerprint.to_uppercase() != key_info.fingerprint.to_uppercase() {
+                eprintln!(
+                    "tcli:      Subkey fingerprint: {}",
+                    verifier_fingerprint.to_uppercase()
+                );
+            }
+            VerifyExit::Good
+        }
+        VerifyOutcome::Bad { key_info } => {
+            eprintln!(
+                "tcli: BAD signature by key {}",
+                key_info.fingerprint.to_uppercase()
+            );
+            print_uids("                       claimed UID:", &key_info);
+            VerifyExit::Bad
+        }
+        VerifyOutcome::UnknownKey { key_id } => {
+            eprintln!(
+                "tcli: Unknown signer; key ID {} is not in the keystore.",
+                key_id
+            );
+            eprintln!("tcli: Use --with-key <PUB_FILE> to verify against an external public key.");
+            VerifyExit::Unknown
+        }
+    }
+}
+
+/// Same human output as the keystore path, but for the external-key
+/// branch where we have a `KeyInfo` parsed from the supplied file.
+fn report_external(cert_info: &KeyInfo, valid: bool) {
+    if valid {
+        print_uids("Good signature from", cert_info);
+        eprintln!(
+            "tcli: Primary key fingerprint: {}  (verified against --with-key)",
+            cert_info.fingerprint.to_uppercase()
+        );
+    } else {
+        eprintln!(
+            "tcli: BAD signature against --with-key (fingerprint {})",
+            cert_info.fingerprint.to_uppercase()
+        );
+        print_uids("                       claimed UID:", cert_info);
+    }
+}
+
+/// Render every non-revoked UID, primary first; first one prefixed with
+/// `lead`, the rest as `aka`.
+fn print_uids(lead: &str, key_info: &KeyInfo) {
+    let mut uids: Vec<_> = key_info.user_ids.iter().filter(|u| !u.revoked).collect();
+    uids.sort_by_key(|u| std::cmp::Reverse(u.is_primary));
+
+    if uids.is_empty() {
+        eprintln!("tcli: {} key {}", lead, key_info.fingerprint.to_uppercase());
+        return;
+    }
+
+    for (i, uid) in uids.iter().enumerate() {
+        if i == 0 {
+            eprintln!("tcli: {} \"{}\"", lead, sanitize_uid(&uid.value));
+        } else {
+            eprintln!("tcli:                 aka \"{}\"", sanitize_uid(&uid.value));
+        }
+    }
+}
+
+fn read_input(input: &Path) -> Result<Vec<u8>> {
+    if is_stdio(input) {
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .context("Failed to read from stdin")?;
+        Ok(buf)
+    } else {
+        std::fs::read(input).with_context(|| format!("Failed to read {}", input.display()))
+    }
+}

--- a/tests/test_sign_verify.sh
+++ b/tests/test_sign_verify.sh
@@ -144,8 +144,8 @@ echo "[2] Detached signature, --binary"
 rm -f payload.txt.sig
 expect_file "  --sign --binary -> FILE.sig" payload.txt.sig \
     -- "$TCLI" --sign payload.txt --with-key "$KEY_FP" --binary
-# Binary form must NOT contain the BEGIN PGP marker.
-if grep -q "BEGIN PGP" payload.txt.sig; then
+# Binary form must NOT start with the ASCII armor header.
+if LC_ALL=C head -c 64 payload.txt.sig | grep -aq '^-----BEGIN PGP SIGNATURE-----$'; then
     echo "  FAIL  --binary output contains BEGIN PGP marker"
     FAIL_COUNT=$((FAIL_COUNT + 1))
 else
@@ -167,7 +167,8 @@ echo
 
 # 4. Inline (cleartext) sign + verify
 echo "[4] Inline cleartext sign + verify"
-expect_file "  --sign-inline -> FILE.asc" payload.txt.asc \
+rm -f payload.signed.asc
+expect_file "  --sign-inline -> payload.signed.asc" payload.signed.asc \
     -- "$TCLI" --sign-inline payload.txt --with-key "$KEY_FP" -o payload.signed.asc
 expect_grep "  output is cleartext-signed" "BEGIN PGP SIGNED MESSAGE" payload.signed.asc
 expect_rc 0 "  verify cleartext message" \
@@ -209,7 +210,8 @@ echo
 # 9. --with-key by email (if we found one)
 if [[ -n "$KEY_EMAIL" ]]; then
     echo "[9] --with-key EMAIL"
-    expect_file "  --sign --with-key $KEY_EMAIL" payload.txt.asc \
+    rm -f payload.email.asc
+    expect_file "  --sign --with-key $KEY_EMAIL" payload.email.asc \
         -- "$TCLI" --sign payload.txt --with-key "$KEY_EMAIL" -o payload.email.asc
     expect_rc 0 "  verify email-selected signature" \
         -- "$TCLI" --verify payload.txt --signature payload.email.asc

--- a/tests/test_sign_verify.sh
+++ b/tests/test_sign_verify.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+# Integration test for `tcli --sign / --sign-inline / --verify`.
+#
+# Prerequisites:
+#   - tcli built (cargo build)
+#   - At least one secret signing-capable key in the tumpa keystore.
+#     Provision a throwaway one with tests/provision_test_key.sh.
+#   - TUMPA_PASSPHRASE set for non-interactive runs.
+#
+# Usage:
+#   TUMPA_PASSPHRASE="passphrase" ./tests/test_sign_verify.sh [FINGERPRINT]
+#
+# If FINGERPRINT is omitted, the first secret key in the keystore is used.
+# To run against a fully throwaway key + keystore, do:
+#
+#   export TUMPA_KEYSTORE=$(mktemp -d)/keys.db
+#   export TUMPA_PASSPHRASE=testpass
+#   fp=$(./tests/provision_test_key.sh)
+#   ./tests/test_sign_verify.sh "$fp"
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TCLI="$PROJECT_DIR/target/debug/tcli"
+
+if [[ ! -x "$TCLI" ]]; then
+    echo "ERROR: tcli not found at $TCLI"
+    echo "Run 'cargo build' first."
+    exit 1
+fi
+
+if [[ -z "${TUMPA_PASSPHRASE:-}" ]]; then
+    echo "ERROR: TUMPA_PASSPHRASE must be set for non-interactive testing."
+    exit 1
+fi
+
+# Pick a key fingerprint and primary email.
+if [[ -n "${1:-}" ]]; then
+    KEY_FP="$1"
+else
+    KEY_FP=$("$TCLI" --list-keys 2>/dev/null \
+        | grep "^sec" \
+        | head -1 \
+        | awk '{print $2}')
+fi
+if [[ -z "$KEY_FP" ]]; then
+    echo "ERROR: no secret key in keystore. Run tests/provision_test_key.sh first."
+    exit 1
+fi
+
+# Try to extract the first email from the key info; used for --with-key EMAIL
+# coverage. Fall back to skipping the email cases if we can't find one.
+KEY_EMAIL=$("$TCLI" --info "$KEY_FP" 2>/dev/null \
+    | grep -oE '<[^>]+@[^>]+>' \
+    | head -1 \
+    | tr -d '<>')
+
+echo "Using key: $KEY_FP"
+[[ -n "$KEY_EMAIL" ]] && echo "Using email: $KEY_EMAIL" || echo "(no email UID found; skipping email-selection cases)"
+
+# --- Test runner ---
+
+WORK_DIR=$(mktemp -d -t tcli-sv-XXXXXX)
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+# Run a command, capture its stderr, and check the exit code matches `$1`.
+# Usage: expect_rc <expected_rc> <name> -- <cmd> [args...]
+expect_rc() {
+    local expected="$1"
+    local name="$2"
+    shift 2
+    [[ "$1" == "--" ]] && shift
+    local err_log
+    err_log=$(mktemp)
+    "$@" >/dev/null 2>"$err_log"
+    local rc=$?
+    if [[ "$rc" -eq "$expected" ]]; then
+        echo "  OK   $name (rc=$rc)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "  FAIL $name (expected rc=$expected, got rc=$rc)"
+        echo "       stderr:"
+        sed 's/^/         /' "$err_log"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+    rm -f "$err_log"
+}
+
+# Run a command, expect rc=0, and check that a file exists.
+expect_file() {
+    local name="$1"
+    local path="$2"
+    shift 2
+    [[ "$1" == "--" ]] && shift
+    if "$@" >/dev/null 2>&1 && [[ -f "$path" ]]; then
+        echo "  OK   $name ($path created)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "  FAIL $name ($path not created or command failed)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+# Run a command, expect its stdout to contain the given string.
+expect_grep() {
+    local name="$1"
+    local pattern="$2"
+    local file="$3"
+    if grep -q "$pattern" "$file"; then
+        echo "  OK   $name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "  FAIL $name (pattern '$pattern' not found in $file)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+cd "$WORK_DIR"
+
+# --- Fixtures ---
+echo "hello world" > payload.txt
+echo "tampered"    > tampered.txt
+
+echo
+echo "=== tcli sign / verify integration tests ==="
+echo
+
+# 1. Detached, default = ASCII armored, sibling .asc
+echo "[1] Detached signature, default armored"
+expect_file "  --sign FILE -> FILE.asc" payload.txt.asc \
+    -- "$TCLI" --sign payload.txt --with-key "$KEY_FP"
+expect_grep "  output is ASCII armored" "BEGIN PGP SIGNATURE" payload.txt.asc
+expect_rc 0 "  verify good" \
+    -- "$TCLI" --verify payload.txt --signature payload.txt.asc
+echo
+
+# 2. Detached, --binary -> sibling .sig
+echo "[2] Detached signature, --binary"
+rm -f payload.txt.sig
+expect_file "  --sign --binary -> FILE.sig" payload.txt.sig \
+    -- "$TCLI" --sign payload.txt --with-key "$KEY_FP" --binary
+# Binary form must NOT contain the BEGIN PGP marker.
+if grep -q "BEGIN PGP" payload.txt.sig; then
+    echo "  FAIL  --binary output contains BEGIN PGP marker"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "  OK   --binary output is binary"
+    PASS_COUNT=$((PASS_COUNT + 1))
+fi
+expect_rc 0 "  verify binary signature" \
+    -- "$TCLI" --verify payload.txt --signature payload.txt.sig
+echo
+
+# 3. -o overrides default destination
+echo "[3] -o/--output override"
+rm -f custom.asc
+expect_file "  --sign -o custom.asc" custom.asc \
+    -- "$TCLI" --sign payload.txt --with-key "$KEY_FP" -o custom.asc
+expect_rc 0 "  verify custom.asc" \
+    -- "$TCLI" --verify payload.txt --signature custom.asc
+echo
+
+# 4. Inline (cleartext) sign + verify
+echo "[4] Inline cleartext sign + verify"
+expect_file "  --sign-inline -> FILE.asc" payload.txt.asc \
+    -- "$TCLI" --sign-inline payload.txt --with-key "$KEY_FP" -o payload.signed.asc
+expect_grep "  output is cleartext-signed" "BEGIN PGP SIGNED MESSAGE" payload.signed.asc
+expect_rc 0 "  verify cleartext message" \
+    -- "$TCLI" --verify payload.signed.asc
+echo
+
+# 5. BAD signature -> exit 1
+echo "[5] BAD signature"
+expect_rc 1 "  verify tampered data" \
+    -- "$TCLI" --verify tampered.txt --signature payload.txt.asc
+echo
+
+# 6. UNKNOWN signer -> exit 2
+echo "[6] UNKNOWN signer (fresh empty keystore)"
+FRESH_DB=$(mktemp -d)/empty.db
+expect_rc 2 "  verify against empty keystore" \
+    -- env TUMPA_KEYSTORE="$FRESH_DB" "$TCLI" --verify payload.txt --signature payload.txt.asc
+echo
+
+# 7. UNKNOWN keystore + --with-key external pubkey -> exit 0
+echo "[7] --with-key external pubkey"
+"$TCLI" --export "$KEY_FP" --armor -o pub.asc >/dev/null 2>&1
+expect_rc 0 "  verify with external --with-key" \
+    -- env TUMPA_KEYSTORE="$FRESH_DB" "$TCLI" --verify payload.txt --signature payload.txt.asc --with-key pub.asc
+expect_rc 0 "  verify inline with external --with-key" \
+    -- env TUMPA_KEYSTORE="$FRESH_DB" "$TCLI" --verify payload.signed.asc --with-key pub.asc
+expect_rc 1 "  external --with-key catches tampered data" \
+    -- env TUMPA_KEYSTORE="$FRESH_DB" "$TCLI" --verify tampered.txt --signature payload.txt.asc --with-key pub.asc
+echo
+
+# 8. stdin -> stdout sign and verify
+echo "[8] stdin / stdout sign"
+cat payload.txt | "$TCLI" --sign - --with-key "$KEY_FP" -o - > stdin-sig.asc 2>/dev/null
+expect_grep "  stdin sign produces armored output on stdout" "BEGIN PGP SIGNATURE" stdin-sig.asc
+expect_rc 0 "  verify stdin-produced signature" \
+    -- "$TCLI" --verify payload.txt --signature stdin-sig.asc
+echo
+
+# 9. --with-key by email (if we found one)
+if [[ -n "$KEY_EMAIL" ]]; then
+    echo "[9] --with-key EMAIL"
+    expect_file "  --sign --with-key $KEY_EMAIL" payload.txt.asc \
+        -- "$TCLI" --sign payload.txt --with-key "$KEY_EMAIL" -o payload.email.asc
+    expect_rc 0 "  verify email-selected signature" \
+        -- "$TCLI" --verify payload.txt --signature payload.email.asc
+    echo
+fi
+
+# 10. Unknown email -> non-zero
+echo "[10] Unknown email is rejected"
+expect_rc 1 "  --sign --with-key nonexistent@example.com" \
+    -- "$TCLI" --sign payload.txt --with-key "this-address-does-not-exist@example.com" -o /dev/null
+echo
+
+# 11. CLI parse-time rejections (no key/keystore touched)
+echo "[11] CLI parse rejections"
+expect_rc 1 "  --sign without --with-key" \
+    -- "$TCLI" --sign payload.txt
+expect_rc 1 "  --sign-inline without --with-key" \
+    -- "$TCLI" --sign-inline payload.txt
+expect_rc 1 "  --sign-inline rejects --binary" \
+    -- "$TCLI" --sign-inline payload.txt --with-key "$KEY_FP" --binary
+expect_rc 1 "  --sign + --verify together" \
+    -- "$TCLI" --sign payload.txt --verify payload.txt --with-key "$KEY_FP"
+expect_rc 1 "  --signature without --verify" \
+    -- "$TCLI" --signature payload.txt.asc --list-keys
+expect_rc 1 "  --with-key without sign/verify" \
+    -- "$TCLI" --with-key "$KEY_FP" --list-keys
+expect_rc 1 "  --verify - without --signature (stdin needs detached)" \
+    -- bash -c "echo data | '$TCLI' --verify -"
+echo
+
+# 12. Inline verify of tampered cleartext -> BAD
+echo "[12] Inline verify catches tampered cleartext"
+# Tamper a single byte inside the cleartext payload region (between
+# the SIGNED-MESSAGE header block and the SIGNATURE block).
+python3 - <<PY > tampered.signed.asc
+import sys
+data = open("payload.signed.asc", "rb").read()
+# Split on the signature delimiter; mutate one byte in the payload region.
+marker = b"-----BEGIN PGP SIGNATURE-----"
+idx = data.find(marker)
+assert idx > 0, "marker not found"
+head, tail = data[:idx], data[idx:]
+# Find a printable byte inside the cleartext body and bump it.
+body_start = head.find(b"\n\n") + 2
+assert body_start > 1
+mutated = bytearray(head)
+for i in range(body_start, len(mutated) - 1):
+    if 0x20 <= mutated[i] < 0x7e:
+        mutated[i] = mutated[i] + 1
+        break
+sys.stdout.buffer.write(bytes(mutated))
+sys.stdout.buffer.write(tail)
+PY
+expect_rc 1 "  inline verify of tampered cleartext" \
+    -- "$TCLI" --verify tampered.signed.asc
+echo
+
+# --- Summary ---
+
+echo "============================================"
+echo "Pass: $PASS_COUNT"
+echo "Fail: $FAIL_COUNT"
+echo "============================================"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Separate agent cache entries for card PINs vs key passphrases so inline signing and decrypt flows cannot reuse the wrong secret type.

Also:
- wire test_sign_verify.sh into the normal test targets
- fix the experimental WhichKey import so --features experimental builds cleanly again
- drop local Serena metadata from the repo