### PR TITLE
feat(tcli): add `cache clear` subcommand

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1024,6 +1024,25 @@ tcli agent --cache-ttl 3600   # 1 hour (default: 1800 = 30 min)
 Cached passphrases expire after the TTL. A background task sweeps
 expired entries every 60 seconds.
 
+### Clearing cached credentials
+
+Drop entries from the running agent without restarting it:
+
+```
+tcli cache clear                # clears every cached passphrase and PIN
+tcli cache clear <FINGERPRINT>  # clears the cached secrets for one key
+```
+
+With no argument, every entry is wiped. With a 40- or 16-hex
+fingerprint, the cached passphrase **and** card PIN tied to that key
+are dropped (so the next signing or decryption operation will re-prompt
+via pinentry). The agent must be running — `tcli cache clear` errors
+out with `Agent socket … does not exist. Start it with \`tcli agent\``
+if it isn't.
+
+Common uses: rotating a key's passphrase, recovering after a wrong PIN,
+or forcing a re-prompt before handing the laptop to someone else.
+
 ### Starting the agent automatically
 
 #### macOS (Launch Agent)

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -207,6 +207,14 @@ async fn handle_client(
                     cache.remove(&cache_key);
                     protocol::Response::Ok
                 }
+                protocol::Request::ClearAll => {
+                    let mut cache = cache.lock().map_err(|_| anyhow::anyhow!("Lock poisoned"))?;
+                    // sweep(0) drops every entry: cutoff = now, no entry's
+                    // stored_at can be strictly greater than now.
+                    let removed = cache.sweep(0);
+                    log::info!("Cache cleared by client: {} entries removed", removed);
+                    protocol::Response::Ok
+                }
             }
         } else {
             protocol::Response::NotFound

--- a/src/agent/protocol.rs
+++ b/src/agent/protocol.rs
@@ -11,6 +11,9 @@
 //!
 //! Client → Agent:  CLEAR_PASSPHRASE <cache-key>\n
 //! Agent → Client:  OK\n
+//!
+//! Client → Agent:  CLEAR_ALL\n
+//! Agent → Client:  OK\n
 //! ```
 
 use anyhow::{Context, Result};
@@ -49,6 +52,7 @@ pub enum Request {
     Clear {
         cache_key: String,
     },
+    ClearAll,
 }
 
 /// A response from the agent to a client.
@@ -94,6 +98,10 @@ pub fn parse_request(line: &str) -> Option<Request> {
                 cache_key: cache_key.to_string(),
             });
         }
+    }
+
+    if line == "CLEAR_ALL" {
+        return Some(Request::ClearAll);
     }
 
     None
@@ -174,5 +182,17 @@ mod tests {
     fn parse_request_rejects_invalid_namespaced_cache_keys() {
         assert!(parse_request("GET_PASSPHRASE other:0123456789ABCDEF\n").is_none());
         assert!(parse_request("GET_PASSPHRASE pin:not-hex\n").is_none());
+    }
+
+    #[test]
+    fn parse_request_accepts_clear_all() {
+        assert!(matches!(parse_request("CLEAR_ALL\n"), Some(Request::ClearAll)));
+        assert!(matches!(parse_request("CLEAR_ALL"), Some(Request::ClearAll)));
+    }
+
+    #[test]
+    fn parse_request_clear_all_does_not_swallow_garbage_suffix() {
+        // "CLEAR_ALL extra" is not a valid request — the verb takes no argument.
+        assert!(parse_request("CLEAR_ALL extra\n").is_none());
     }
 }

--- a/src/cache_cmd.rs
+++ b/src/cache_cmd.rs
@@ -37,7 +37,9 @@ pub fn cmd_cache_clear(target: Option<&str>) -> Result<()> {
             eprintln!("Cleared all cached credentials.");
         }
         Some(fp) => {
-            let fp = fp.trim();
+            // Validate the raw input — do NOT trim. A trailing newline or
+            // space here would otherwise be silently accepted, which the
+            // validator's `is_ascii_hexdigit()` check is meant to reject.
             if !is_valid_fingerprint(fp) {
                 bail!(
                     "{:?} is not a valid fingerprint (expected 40 or 16 hex characters).",
@@ -90,7 +92,8 @@ fn send_line(socket_path: &Path, request: &str) -> Result<()> {
         .context("Failed to send request to agent")?;
 
     let mut response = String::new();
-    BufReader::new(&stream)
+    let mut reader = BufReader::new(&stream);
+    reader
         .read_line(&mut response)
         .context("Failed to read response from agent")?;
 
@@ -157,5 +160,24 @@ mod tests {
         assert_eq!(keys[0], "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD");
         assert!(keys[1].starts_with("pin:ABCD"));
         assert!(keys[2].starts_with("passphrase:ABCD"));
+    }
+
+    // Pins PR #25 review feedback: cmd_cache_clear must reject whitespace-
+    // padded argv, not silently strip it. Whitespace-padded fingerprints
+    // would otherwise reach the agent's wire and could split into
+    // multiple line-protocol verbs if a `\n` slipped through.
+    #[test]
+    fn whitespace_padded_input_fails_validation() {
+        // Trailing/leading space and trailing newline are all rejected.
+        assert!(!is_valid_fingerprint(
+            " ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD"
+        ));
+        assert!(!is_valid_fingerprint(
+            "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD "
+        ));
+        assert!(!is_valid_fingerprint(
+            "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD\n"
+        ));
+        assert!(!is_valid_fingerprint("\tABCDABCDABCDABCD"));
     }
 }

--- a/src/cache_cmd.rs
+++ b/src/cache_cmd.rs
@@ -1,0 +1,161 @@
+//! `tcli cache` subcommand handlers.
+//!
+//! Talks to the running `tcli agent` over `~/.tumpa/agent.sock` using the
+//! line protocol defined in [`crate::agent::protocol`].
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::agent;
+use crate::agent::protocol;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Clear cache entries on the running agent.
+///
+/// - `target = None` → send a single `CLEAR_ALL` and wipe the entire cache.
+/// - `target = Some(fp)` → send three `CLEAR_PASSPHRASE` requests, one for the
+///   raw fingerprint and one for each `pin:` / `passphrase:` slot, so callers
+///   don't need to know the cache-key namespacing.
+pub fn cmd_cache_clear(target: Option<&str>) -> Result<()> {
+    let socket_path = agent::default_socket_path()?;
+
+    if !socket_path.exists() {
+        bail!(
+            "Agent socket {} does not exist. Start it with `tcli agent`.",
+            socket_path.display()
+        );
+    }
+
+    match target {
+        None => {
+            send_line(&socket_path, "CLEAR_ALL\n")?;
+            eprintln!("Cleared all cached credentials.");
+        }
+        Some(fp) => {
+            let fp = fp.trim();
+            if !is_valid_fingerprint(fp) {
+                bail!(
+                    "{:?} is not a valid fingerprint (expected 40 or 16 hex characters).",
+                    fp
+                );
+            }
+            // Cache producers (gpg/sign.rs, gpg/decrypt.rs, …) always pass
+            // `key_info.fingerprint` from the keystore, which is uppercase.
+            // Normalise here so a user pasting a lowercase fingerprint
+            // actually clears the entries instead of silently no-op'ing.
+            let fp = fp.to_uppercase();
+            for cache_key in cache_keys_for_fingerprint(&fp) {
+                send_line(&socket_path, &format!("CLEAR_PASSPHRASE {cache_key}\n"))?;
+            }
+            eprintln!("Cleared cached credentials for {fp}.");
+        }
+    }
+
+    Ok(())
+}
+
+fn is_valid_fingerprint(s: &str) -> bool {
+    matches!(s.len(), 16 | 40) && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Three cache keys an entry tied to `fp` may live under: bare fingerprint,
+/// `pin:<fp>`, and `passphrase:<fp>`. Caller must have already normalised
+/// `fp` to the case the agent stores under (uppercase).
+fn cache_keys_for_fingerprint(fp: &str) -> [String; 3] {
+    [
+        fp.to_string(),
+        format!("pin:{fp}"),
+        format!("passphrase:{fp}"),
+    ]
+}
+
+fn send_line(socket_path: &Path, request: &str) -> Result<()> {
+    let mut stream = UnixStream::connect(socket_path)
+        .with_context(|| format!("Failed to connect to agent at {}", socket_path.display()))?;
+
+    stream
+        .set_read_timeout(Some(REQUEST_TIMEOUT))
+        .context("Failed to set socket read timeout")?;
+    stream
+        .set_write_timeout(Some(REQUEST_TIMEOUT))
+        .context("Failed to set socket write timeout")?;
+
+    stream
+        .write_all(request.as_bytes())
+        .context("Failed to send request to agent")?;
+
+    let mut response = String::new();
+    BufReader::new(&stream)
+        .read_line(&mut response)
+        .context("Failed to read response from agent")?;
+
+    match protocol::parse_response(&response) {
+        Some(protocol::Response::Ok) => Ok(()),
+        Some(_) => Err(anyhow!(
+            "Unexpected response from agent: {}",
+            response.trim()
+        )),
+        None => Err(anyhow!(
+            "Agent returned an unparseable response: {:?}",
+            response
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cache_keys_for_fingerprint, is_valid_fingerprint};
+
+    #[test]
+    fn fingerprint_validator_accepts_both_cases_and_lengths() {
+        assert!(is_valid_fingerprint("ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD"));
+        assert!(is_valid_fingerprint("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"));
+        assert!(is_valid_fingerprint("ABCDABCDABCDABCD"));
+        assert!(is_valid_fingerprint("abcdabcdabcdabcd"));
+    }
+
+    #[test]
+    fn fingerprint_validator_rejects_garbage() {
+        assert!(!is_valid_fingerprint(""));
+        assert!(!is_valid_fingerprint("ABCD"));
+        assert!(!is_valid_fingerprint("not-hex-not-hex"));
+        // length 41 — must reject (a leading 0xnnnn… form would slip through
+        // otherwise and shift cache-key namespacing).
+        assert!(!is_valid_fingerprint(
+            "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDA"
+        ));
+        // injection attempts
+        assert!(!is_valid_fingerprint(
+            "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABC\n"
+        ));
+        assert!(!is_valid_fingerprint(
+            "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABC "
+        ));
+    }
+
+    #[test]
+    fn cache_keys_for_fingerprint_emits_three_namespaced_variants() {
+        let keys = cache_keys_for_fingerprint("ABCDABCDABCDABCD");
+        assert_eq!(keys[0], "ABCDABCDABCDABCD");
+        assert_eq!(keys[1], "pin:ABCDABCDABCDABCD");
+        assert_eq!(keys[2], "passphrase:ABCDABCDABCDABCD");
+    }
+
+    // Pins L-1 from DIFFERENTIAL_REVIEW_CACHE_CLEAR_2026-04-29.md: a user
+    // typing a lowercase fingerprint must produce the same cache keys as a
+    // signer storing entries via `key_info.fingerprint` (uppercase).
+    #[test]
+    fn lowercase_user_input_normalises_to_match_keystore_casing() {
+        let user_input = "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd";
+        let normalised = user_input.to_uppercase();
+        let keys = cache_keys_for_fingerprint(&normalised);
+        assert_eq!(keys[0], "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD");
+        assert!(keys[1].starts_with("pin:ABCD"));
+        assert!(keys[2].starts_with("passphrase:ABCD"));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,10 @@ pub enum Command {
     #[clap(subcommand)]
     Card(CardCommand),
 
+    /// Manage the running agent's in-memory credential cache.
+    #[clap(subcommand)]
+    Cache(CacheCommand),
+
     /// Print an agent socket path. Default `gpg`; pass `ssh` for the SSH socket.
     Socket {
         /// Which socket to print.
@@ -247,6 +251,20 @@ pub enum CardCommand {
         /// Skip confirmation prompt.
         #[clap(short = 'y', long)]
         yes: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CacheCommand {
+    /// Drop cached credentials from the running agent.
+    ///
+    /// With no argument, every entry is cleared. With a fingerprint
+    /// (40 or 16 hex chars), only that key's cached passphrase and PIN
+    /// are dropped. The agent must be running.
+    Clear {
+        /// Optional fingerprint or key ID. Omit to clear every entry.
+        #[clap(value_name = "FINGERPRINT_OR_KEYID")]
+        target: Option<String>,
     },
 }
 
@@ -351,6 +369,9 @@ pub enum Mode {
         input: PathBuf,
         signature: Option<PathBuf>,
         with_key_file: Option<PathBuf>,
+    },
+    CacheClear {
+        target: Option<String>,
     },
     None,
 }
@@ -471,6 +492,8 @@ fn mode_from_subcommand(cmd: Command) -> Result<Mode, String> {
 
         Command::Card(card) => mode_from_card(card),
 
+        Command::Cache(cache) => mode_from_cache(cache),
+
         Command::Socket { kind } => Ok(Mode::ShowSocket {
             ssh: kind == SocketKind::Ssh,
         }),
@@ -541,6 +564,12 @@ fn mode_from_card(cmd: CardCommand) -> Result<Mode, String> {
             let _ = yes;
             Ok(Mode::ResetCard { card_ident })
         }
+    }
+}
+
+fn mode_from_cache(cmd: CacheCommand) -> Result<Mode, String> {
+    match cmd {
+        CacheCommand::Clear { target } => Ok(Mode::CacheClear { target }),
     }
 }
 
@@ -856,6 +885,33 @@ mod tests {
             parse(&["completions", "zsh"]),
             Ok(Mode::Completions { .. })
         ));
+    }
+
+    // ----- cache -----
+
+    #[test]
+    fn cache_clear_no_args_clears_all() {
+        match parse(&["cache", "clear"]).unwrap() {
+            Mode::CacheClear { target } => assert!(target.is_none()),
+            other => panic!(
+                "expected CacheClear, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn cache_clear_with_fingerprint() {
+        match parse(&["cache", "clear", "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD"]).unwrap() {
+            Mode::CacheClear { target } => assert_eq!(
+                target.as_deref(),
+                Some("ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD")
+            ),
+            other => panic!(
+                "expected CacheClear, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
     }
 
     // ----- pre-0.4 flag forms are gone -----

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod cache_cmd;
 pub mod cli;
 pub mod gpg;
 pub mod keystore;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::io::stdout;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use tumpa_cli::{keystore, pinentry, sign_cmd, ssh, store, verify_cmd};
+use tumpa_cli::{cache_cmd, keystore, pinentry, sign_cmd, ssh, store, verify_cmd};
 
 use cli::*;
 
@@ -124,6 +124,7 @@ fn main() {
             with_key,
             output,
         }) => sign_cmd::cmd_sign_inline(&input, &with_key, output.as_ref(), keystore_path.as_ref()),
+        Ok(Mode::CacheClear { target }) => cache_cmd::cmd_cache_clear(target.as_deref()),
         Ok(Mode::Verify {
             input,
             signature,


### PR DESCRIPTION
Adds `tcli cache clear [FINGERPRINT]` to drop credentials from the running agent without restarting it. With no argument every entry is cleared; with a 40- or 16-hex fingerprint the bare, pin: and passphrase: slots for that key are dropped.

Extends the agent line protocol on ~/.tumpa/agent.sock with a new CLEAR_ALL verb. Server-side the handler calls cache.sweep(0), which drops every entry (the sweep predicate is strictly greater-than, so a 0-second TTL evicts all). Existing GET_PASSPHRASE / PUT_PASSPHRASE / CLEAR_PASSPHRASE verbs are untouched.

User input is normalised to uppercase before building cache keys so a lowercase fingerprint pasted from external tools still matches entries stored by the keystore-driven producers in gpg/sign.rs, gpg/encrypt.rs, gpg/decrypt.rs, sign_cmd.rs and tpass/util/crypto.rs (all of which pass key_info.fingerprint, which the keystore returns in uppercase).

Tests added:
  - 2 protocol parser tests: CLEAR_ALL accept, reject garbage suffix
  - 2 CLI parser tests: no-arg form, with-fingerprint form
  - 4 cache_cmd unit tests: validator coverage (length, hex, newline/space injection rejection), cache-keys helper, and a lowercase-input -> uppercase-cache-key regression test

Docs: new "Clearing cached credentials" section in docs/usage.md under the Agent chapter.