### PR TITLE
fix: sign inline help message incorrectly referred to software keys

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,7 +114,7 @@ pub enum Command {
         binary: bool,
     },
 
-    /// Create an inline (cleartext) signature. Software keys only.
+    /// Create an inline (cleartext) signature.
     SignInline {
         /// Input file. Use `-` for stdin (then `-o`/`--output` is required).
         #[clap(value_name = "FILE")]


### PR DESCRIPTION
The `sign-inline` help message incorrectly states "only software keys", which is not the case.
