### PR TITLE
feat(tcli): add `card link` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3367,7 +3367,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tumpa-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tumpa-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "OpenPGP operations and SSH agent backed by tumpa keystore."
 license = "GPL-3.0-or-later"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1293,6 +1293,52 @@ Card PINs are prompted via pinentry, the same way as software key
 passphrases. Set `TUMPA_PASSPHRASE` for non-interactive card PIN
 entry (e.g., in CI).
 
+### Linking a card to a keystore key
+
+When you upload a key to a card, tumpa records a row in the keystore's
+`card_keys` table mapping each card slot's fingerprint to the
+corresponding key in `~/.tumpa/keys.db`. The SSH agent uses these rows
+to find which card holds the authentication subkey of a given key, so
+**without the link `tcli ssh-agent` advertises no card-backed
+identities** — `ssh-add -L` prints nothing even with the card plugged
+in.
+
+If the link is missing (uploaded with an older tumpa build, or the key
+landed on the card via `gpg --edit-key … keytocard`), repair it from
+the CLI:
+
+```
+tcli card link             # link every match across every connected card
+tcli card link --dry-run   # show what would be written, touch nothing
+```
+
+The command is idempotent (re-running rewrites the same rows), reads
+all connected cards via PCSC, and matches every slot fingerprint
+against every primary and subkey fingerprint in the keystore
+(case-insensitive). It does not prompt for a PIN and does not write
+any APDU to the card.
+
+If multiple cards are connected and you only want to link one of
+them:
+
+```
+tcli card link --card-ident 000F:CB9A5355
+```
+
+The `IDENT` is the value shown by `tcli card list`.
+
+To verify the link worked:
+
+```
+sqlite3 ~/.tumpa/keys.db \
+    "SELECT fingerprint, card_ident, slot FROM card_keys"
+```
+
+You should see one row per provisioned slot (`signature`,
+`encryption`, `authentication`). After this, `tcli ssh-agent` (or
+`tcli agent --ssh`) lists the card's authentication key in
+`ssh-add -L` and accepts SSH auth challenges via the card.
+
 ### Listing connected cards
 
 `tcli` enumerates every OpenPGP card visible to PCSC with:
@@ -1464,6 +1510,23 @@ The encrypted message is addressed to a key you don't have the secret
 for. Check `tcli list` -- keys marked `sec` can decrypt with
 software keys, and keys marked `pub` can decrypt if the corresponding
 OpenPGP card is connected. Make sure `pcscd` is running if using a card.
+
+### `ssh-add -L` shows no card identities even with the card plugged in
+
+If `tcli` / `tclig` / `tpass` work but the SSH side advertises nothing,
+the most common causes are (in order):
+
+1. `SSH_AUTH_SOCK` is unset or points at the system ssh-agent. Run
+   `echo "$SSH_AUTH_SOCK"` and compare against `tcli socket ssh`.
+2. The agent isn't serving SSH. `tcli agent` alone binds the GPG
+   cache only — use `tcli agent --ssh` (or the systemd
+   `tumpa-agent.service` / `tumpa-ssh-agent.service` units).
+3. The card has the auth subkey but the keystore doesn't know which
+   key it belongs to. Run `tcli card link` (see [Linking a card to a
+   keystore key](#linking-a-card-to-a-keystore-key)) to write the
+   missing `card_keys` rows.
+4. The keystore has no auth-capable subkey at all. `tcli describe
+   <FP>` should list a subkey with `[A]` capability.
 
 ### "Failed to enumerate cards" or card errors
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1293,6 +1293,35 @@ Card PINs are prompted via pinentry, the same way as software key
 passphrases. Set `TUMPA_PASSPHRASE` for non-interactive card PIN
 entry (e.g., in CI).
 
+### Seeing which cards hold a key
+
+`tcli describe <FINGERPRINT>` appends a `Cards:` block when one or
+more cards are linked to the cert. One key may live on multiple cards
+at once (e.g. a backup card, or signing on YubiKey + auth on Nitrokey
+in the same cert), so cards are grouped per ident with a compact
+`[S E A]` slot tag (signature, encryption, authentication):
+
+```
+sec  ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD  ed25519  [sign, certify]
+     Created:  2024-01-01 12:00:00 UTC
+     Expires:  2026-01-01 12:00:00 UTC
+     UIDs:
+       [primary] Alice <alice@example.com>
+     Subkeys:
+       12121212...  cv25519       [encryption]
+                 Created:  2024-01-01 12:00:00 UTC
+       EFEFEFEF...  ed25519       [authentication]
+                 Created:  2024-01-01 12:00:00 UTC
+     Cards:
+       000F:CB9A5355  Nitrokey GmbH (CB9A5355)  [S E A]
+       0006:00000001  Yubico (00000001)         [S]
+```
+
+The block is sourced from the `card_keys` table — read-only, no PCSC
+probe, no PIN prompt. If you don't see a `Cards:` block when you
+expect one, the link is missing; run [`tcli card
+link`](#linking-a-card-to-a-keystore-key) to repair it.
+
 ### Linking a card to a keystore key
 
 When you upload a key to a card, tumpa records a row in the keystore's

--- a/src/agent/protocol.rs
+++ b/src/agent/protocol.rs
@@ -186,8 +186,14 @@ mod tests {
 
     #[test]
     fn parse_request_accepts_clear_all() {
-        assert!(matches!(parse_request("CLEAR_ALL\n"), Some(Request::ClearAll)));
-        assert!(matches!(parse_request("CLEAR_ALL"), Some(Request::ClearAll)));
+        assert!(matches!(
+            parse_request("CLEAR_ALL\n"),
+            Some(Request::ClearAll)
+        ));
+        assert!(matches!(
+            parse_request("CLEAR_ALL"),
+            Some(Request::ClearAll)
+        ));
     }
 
     #[test]

--- a/src/cache_cmd.rs
+++ b/src/cache_cmd.rs
@@ -116,8 +116,12 @@ mod tests {
 
     #[test]
     fn fingerprint_validator_accepts_both_cases_and_lengths() {
-        assert!(is_valid_fingerprint("ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD"));
-        assert!(is_valid_fingerprint("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"));
+        assert!(is_valid_fingerprint(
+            "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD"
+        ));
+        assert!(is_valid_fingerprint(
+            "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
+        ));
         assert!(is_valid_fingerprint("ABCDABCDABCDABCD"));
         assert!(is_valid_fingerprint("abcdabcdabcdabcd"));
     }

--- a/src/card_link.rs
+++ b/src/card_link.rs
@@ -1,0 +1,201 @@
+//! `tcli card link` subcommand handler.
+//!
+//! Walks every connected OpenPGP card via `libtumpa::card::link::auto_detect`
+//! and writes a row in the keystore's `card_keys` table for each slot
+//! whose fingerprint matches a primary or subkey of any stored cert.
+//!
+//! Read-write on the keystore. Read-only on the cards (no PIN prompts,
+//! no APDU writes). The ssh-agent + GPG dispatch logic uses these rows
+//! to find the card holding a given key, so without them `ssh-add -L`
+//! returns no card-backed identities even when the card is plugged in.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, bail, Context, Result};
+use libtumpa::card::link::{self, CardKeyDetection};
+use wecanencrypt::card::{get_card_details, CardInfo, KeySlot};
+
+use crate::store;
+
+/// Map a `KeySlot` to the textual name `link::link` expects.
+///
+/// The `card_keys.slot` column is documented as one of these three
+/// strings; the SSH agent's enumerator filters on `slot = "authentication"`,
+/// so any drift here silently breaks ssh-add / git ssh-signing.
+fn slot_str(slot: KeySlot) -> &'static str {
+    match slot {
+        KeySlot::Signature => "signature",
+        KeySlot::Encryption => "encryption",
+        KeySlot::Authentication => "authentication",
+    }
+}
+
+pub fn cmd_card_link(
+    dry_run: bool,
+    filter_card_ident: Option<&str>,
+    keystore_path: Option<&PathBuf>,
+) -> Result<()> {
+    let keystore = store::open_keystore(keystore_path)?;
+
+    let detections = link::auto_detect(&keystore)
+        .map_err(|e| anyhow!("{e}"))
+        .context("failed to auto-detect card↔key matches")?;
+
+    let detections = filter_detections(detections, filter_card_ident)?;
+
+    if detections.is_empty() {
+        if filter_card_ident.is_some() {
+            bail!(
+                "No card slots on the requested card match any key in the keystore. \
+                 Run `tcli card list` to confirm the ident, and `tcli list` to confirm \
+                 the keystore has the matching cert."
+            );
+        }
+        eprintln!("No card slots match any key in the keystore.");
+        return Ok(());
+    }
+
+    print_detections(&detections, dry_run);
+
+    if dry_run {
+        return Ok(());
+    }
+
+    apply_links(&keystore, &detections)?;
+    eprintln!(
+        "Wrote {} card↔key link{} to the keystore.",
+        detections.len(),
+        if detections.len() == 1 { "" } else { "s" }
+    );
+    Ok(())
+}
+
+/// Trim the auto-detect output to the requested card. Pure so it can
+/// be unit-tested without a card or keystore.
+fn filter_detections(
+    detections: Vec<CardKeyDetection>,
+    filter_card_ident: Option<&str>,
+) -> Result<Vec<CardKeyDetection>> {
+    let Some(ident) = filter_card_ident else {
+        return Ok(detections);
+    };
+    let trimmed: Vec<_> = detections
+        .into_iter()
+        .filter(|d| d.card_ident == ident)
+        .collect();
+    Ok(trimmed)
+}
+
+fn print_detections(detections: &[CardKeyDetection], dry_run: bool) {
+    let prefix = if dry_run { "Would link" } else { "Linked" };
+    for d in detections {
+        eprintln!(
+            "{prefix}: card {} slot {} ({}) -> key {}",
+            d.card_ident,
+            slot_str(d.slot),
+            d.slot_fingerprint,
+            d.key_fingerprint,
+        );
+    }
+}
+
+fn apply_links(
+    keystore: &wecanencrypt::KeyStore,
+    detections: &[CardKeyDetection],
+) -> Result<()> {
+    // `link::link` wants `&CardInfo`; `auto_detect` only attached the
+    // lighter `CardSummary` to each row. Re-fetch CardInfo once per
+    // unique ident — typically one PCSC round-trip in practice.
+    let mut info_cache: HashMap<String, CardInfo> = HashMap::new();
+    for d in detections {
+        if !info_cache.contains_key(&d.card_ident) {
+            let info = get_card_details(Some(&d.card_ident))
+                .map_err(|e| anyhow!("{e}"))
+                .with_context(|| format!("failed to read card {}", d.card_ident))?;
+            info_cache.insert(d.card_ident.clone(), info);
+        }
+        let info = &info_cache[&d.card_ident];
+        link::link(
+            keystore,
+            &d.key_fingerprint,
+            info,
+            slot_str(d.slot),
+            &d.slot_fingerprint,
+        )
+        .map_err(|e| anyhow!("{e}"))
+        .with_context(|| {
+            format!(
+                "failed to write link for card {} slot {} → key {}",
+                d.card_ident,
+                slot_str(d.slot),
+                d.key_fingerprint
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_detections, slot_str};
+    use libtumpa::card::link::CardKeyDetection;
+    use wecanencrypt::card::{CardSummary, KeySlot};
+
+    fn detection(card_ident: &str, slot: KeySlot, key_fp: &str) -> CardKeyDetection {
+        CardKeyDetection {
+            key_fingerprint: key_fp.to_string(),
+            card_ident: card_ident.to_string(),
+            card_summary: CardSummary {
+                ident: card_ident.to_string(),
+                manufacturer_name: "Test".to_string(),
+                serial_number: card_ident
+                    .split(':')
+                    .nth(1)
+                    .unwrap_or(card_ident)
+                    .to_string(),
+                cardholder_name: None,
+            },
+            slot,
+            slot_fingerprint: format!("SLOTFP:{key_fp}"),
+        }
+    }
+
+    #[test]
+    fn slot_str_maps_every_variant() {
+        assert_eq!(slot_str(KeySlot::Signature), "signature");
+        assert_eq!(slot_str(KeySlot::Encryption), "encryption");
+        assert_eq!(slot_str(KeySlot::Authentication), "authentication");
+    }
+
+    #[test]
+    fn filter_none_passes_everything_through() {
+        let xs = vec![
+            detection("000F:AAA", KeySlot::Authentication, "FP1"),
+            detection("0006:BBB", KeySlot::Signature, "FP2"),
+        ];
+        let out = filter_detections(xs.clone(), None).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].card_ident, "000F:AAA");
+        assert_eq!(out[1].card_ident, "0006:BBB");
+    }
+
+    #[test]
+    fn filter_matches_card_ident_exactly() {
+        let xs = vec![
+            detection("000F:AAA", KeySlot::Authentication, "FP1"),
+            detection("0006:BBB", KeySlot::Signature, "FP2"),
+            detection("000F:AAA", KeySlot::Encryption, "FP3"),
+        ];
+        let out = filter_detections(xs, Some("000F:AAA")).unwrap();
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|d| d.card_ident == "000F:AAA"));
+    }
+
+    #[test]
+    fn filter_returns_empty_when_no_card_matches() {
+        let xs = vec![detection("000F:AAA", KeySlot::Authentication, "FP1")];
+        let out = filter_detections(xs, Some("DEAD:BEEF")).unwrap();
+        assert!(out.is_empty());
+    }
+}

--- a/src/card_link.rs
+++ b/src/card_link.rs
@@ -173,10 +173,7 @@ fn print_detections(detections: &[CardKeyDetection], dry_run: bool) {
     }
 }
 
-fn apply_links(
-    keystore: &wecanencrypt::KeyStore,
-    detections: &[CardKeyDetection],
-) -> Result<()> {
+fn apply_links(keystore: &wecanencrypt::KeyStore, detections: &[CardKeyDetection]) -> Result<()> {
     // `link::link` wants `&CardInfo`; `auto_detect` only attached the
     // lighter `CardSummary` to each row. Re-fetch CardInfo once per
     // unique ident — typically one PCSC round-trip in practice.

--- a/src/card_link.rs
+++ b/src/card_link.rs
@@ -9,12 +9,13 @@
 //! to find the card holding a given key, so without them `ssh-add -L`
 //! returns no card-backed identities even when the card is plugged in.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
 use libtumpa::card::link::{self, CardKeyDetection};
 use wecanencrypt::card::{get_card_details, CardInfo, KeySlot};
+use wecanencrypt::keystore::StoredCardKey;
 
 use crate::store;
 
@@ -29,6 +30,78 @@ fn slot_str(slot: KeySlot) -> &'static str {
         KeySlot::Encryption => "encryption",
         KeySlot::Authentication => "authentication",
     }
+}
+
+/// Canonical print order for slot labels: signature, encryption,
+/// authentication. Matches `tcli card status` and the OpenPGP card
+/// data-object order.
+fn slot_rank(slot: &str) -> u8 {
+    match slot {
+        "signature" => 0,
+        "encryption" => 1,
+        "authentication" => 2,
+        _ => 99,
+    }
+}
+
+/// Single-letter slot tag used in the `[S E A]` summary on `tcli describe`.
+fn slot_tag(slot: &str) -> &'static str {
+    match slot {
+        "signature" => "S",
+        "encryption" => "E",
+        "authentication" => "A",
+        _ => "?",
+    }
+}
+
+/// Render the "Cards holding this key" footer for `tcli describe`.
+///
+/// Returns an empty Vec if `assocs` is empty (callers shouldn't print a
+/// header in that case). One key may live on multiple cards (e.g.
+/// signing on YubiKey, auth on Nitrokey, or the same key replicated
+/// across two backups), so cards are grouped per `card_ident` and the
+/// slot tags compressed into a single bracketed list per card.
+///
+/// Indentation matches `print_key_info`'s 5-space label gutter.
+pub fn render_card_links_for_key(assocs: &[StoredCardKey]) -> Vec<String> {
+    if assocs.is_empty() {
+        return Vec::new();
+    }
+
+    // Group by card_ident, preserving the manufacturer/serial of the
+    // first row seen for each card (these are identical across rows
+    // for the same ident — the same card row gets the same metadata
+    // every time `auto_link_after_upload` writes it).
+    let mut by_card: BTreeMap<String, (Option<String>, String, Vec<String>)> = BTreeMap::new();
+    for a in assocs {
+        let entry = by_card.entry(a.card_ident.clone()).or_insert_with(|| {
+            (
+                a.card_manufacturer.clone(),
+                a.card_serial.clone(),
+                Vec::new(),
+            )
+        });
+        if !entry.2.contains(&a.slot) {
+            entry.2.push(a.slot.clone());
+        }
+    }
+
+    let mut out = Vec::with_capacity(by_card.len() + 1);
+    out.push("     Cards:".to_string());
+    for (ident, (mfg, serial, mut slots)) in by_card {
+        slots.sort_by_key(|s| slot_rank(s));
+        let tags = slots
+            .iter()
+            .map(|s| slot_tag(s))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let mfg_str = mfg.as_deref().unwrap_or("Unknown");
+        out.push(format!(
+            "       {}  {} ({})  [{}]",
+            ident, mfg_str, serial, tags
+        ));
+    }
+    out
 }
 
 pub fn cmd_card_link(
@@ -138,9 +211,21 @@ fn apply_links(
 
 #[cfg(test)]
 mod tests {
-    use super::{filter_detections, slot_str};
+    use super::{filter_detections, render_card_links_for_key, slot_str};
     use libtumpa::card::link::CardKeyDetection;
     use wecanencrypt::card::{CardSummary, KeySlot};
+    use wecanencrypt::keystore::StoredCardKey;
+
+    fn assoc(card_ident: &str, mfg: Option<&str>, serial: &str, slot: &str) -> StoredCardKey {
+        StoredCardKey {
+            card_ident: card_ident.to_string(),
+            card_serial: serial.to_string(),
+            card_manufacturer: mfg.map(str::to_string),
+            slot: slot.to_string(),
+            slot_fingerprint: format!("SLOTFP:{card_ident}:{slot}"),
+            last_seen: "2026-04-29T00:00:00Z".to_string(),
+        }
+    }
 
     fn detection(card_ident: &str, slot: KeySlot, key_fp: &str) -> CardKeyDetection {
         CardKeyDetection {
@@ -197,5 +282,130 @@ mod tests {
         let xs = vec![detection("000F:AAA", KeySlot::Authentication, "FP1")];
         let out = filter_detections(xs, Some("DEAD:BEEF")).unwrap();
         assert!(out.is_empty());
+    }
+
+    // ---- render_card_links_for_key ----
+
+    #[test]
+    fn render_empty_assocs_returns_empty() {
+        assert!(render_card_links_for_key(&[]).is_empty());
+    }
+
+    #[test]
+    fn render_single_card_single_slot() {
+        let xs = vec![assoc(
+            "000F:CB9A5355",
+            Some("Nitrokey GmbH"),
+            "CB9A5355",
+            "authentication",
+        )];
+        let out = render_card_links_for_key(&xs);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], "     Cards:");
+        assert_eq!(
+            out[1],
+            "       000F:CB9A5355  Nitrokey GmbH (CB9A5355)  [A]"
+        );
+    }
+
+    #[test]
+    fn render_single_card_three_slots_sorted_canonical() {
+        // Input order is reversed; render must reorder to S E A.
+        let xs = vec![
+            assoc(
+                "000F:CB9A5355",
+                Some("Nitrokey GmbH"),
+                "CB9A5355",
+                "authentication",
+            ),
+            assoc(
+                "000F:CB9A5355",
+                Some("Nitrokey GmbH"),
+                "CB9A5355",
+                "encryption",
+            ),
+            assoc(
+                "000F:CB9A5355",
+                Some("Nitrokey GmbH"),
+                "CB9A5355",
+                "signature",
+            ),
+        ];
+        let out = render_card_links_for_key(&xs);
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[1],
+            "       000F:CB9A5355  Nitrokey GmbH (CB9A5355)  [S E A]"
+        );
+    }
+
+    // Pins option-2 motivation from the design discussion: one key
+    // can live on multiple cards (e.g. signing on YubiKey, auth on
+    // Nitrokey, or the same key replicated across two backups).
+    // Render must group per-card and emit one line per `card_ident`.
+    #[test]
+    fn render_multiple_cards_grouped_by_ident() {
+        let xs = vec![
+            assoc(
+                "000F:CB9A5355",
+                Some("Nitrokey GmbH"),
+                "CB9A5355",
+                "authentication",
+            ),
+            assoc("0006:00000001", Some("Yubico"), "00000001", "signature"),
+            assoc(
+                "000F:CB9A5355",
+                Some("Nitrokey GmbH"),
+                "CB9A5355",
+                "encryption",
+            ),
+        ];
+        let out = render_card_links_for_key(&xs);
+        // header + 2 card lines (Yubico sorts before Nitrokey by
+        // BTreeMap on the card_ident key string).
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0], "     Cards:");
+        assert!(
+            out[1].contains("0006:00000001") && out[1].ends_with("[S]"),
+            "got: {}",
+            out[1]
+        );
+        assert!(
+            out[2].contains("000F:CB9A5355") && out[2].ends_with("[E A]"),
+            "got: {}",
+            out[2]
+        );
+    }
+
+    #[test]
+    fn render_unknown_manufacturer_falls_back_to_unknown() {
+        let xs = vec![assoc("FFFF:DEADBEEF", None, "DEADBEEF", "signature")];
+        let out = render_card_links_for_key(&xs);
+        assert_eq!(out[1], "       FFFF:DEADBEEF  Unknown (DEADBEEF)  [S]");
+    }
+
+    #[test]
+    fn render_dedupes_duplicate_slot_rows_per_card() {
+        // Defensive: if two rows ever share (card_ident, slot) the
+        // tag list still has each letter once.
+        let xs = vec![
+            assoc(
+                "000F:CB9A5355",
+                Some("Nitrokey GmbH"),
+                "CB9A5355",
+                "authentication",
+            ),
+            assoc(
+                "000F:CB9A5355",
+                Some("Nitrokey GmbH"),
+                "CB9A5355",
+                "authentication",
+            ),
+        ];
+        let out = render_card_links_for_key(&xs);
+        // Check the bracketed tag specifically, not the whole line —
+        // serial "CB9A5355" already contains 'A'.
+        assert!(out[1].ends_with("[A]"), "got: {}", out[1]);
+        assert!(!out[1].contains("[A A]"));
     }
 }

--- a/src/card_link.rs
+++ b/src/card_link.rs
@@ -12,7 +12,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use libtumpa::card::link::{self, CardKeyDetection};
 use wecanencrypt::card::{get_card_details, CardInfo, KeySlot};
 use wecanencrypt::keystore::StoredCardKey;
@@ -112,7 +112,6 @@ pub fn cmd_card_link(
     let keystore = store::open_keystore(keystore_path)?;
 
     let detections = link::auto_detect(&keystore)
-        .map_err(|e| anyhow!("{e}"))
         .context("failed to auto-detect card↔key matches")?;
 
     let detections = filter_detections(detections, filter_card_ident)?;
@@ -129,13 +128,18 @@ pub fn cmd_card_link(
         return Ok(());
     }
 
-    print_detections(&detections, dry_run);
-
     if dry_run {
+        // Dry-run prints "Would link: ..." up front and writes nothing.
+        print_detections(&detections, true);
         return Ok(());
     }
 
+    // Write first, then announce. Printing "Linked: ..." up front and
+    // failing partway through `apply_links` would tell the user every
+    // row was written when only a prefix actually was; the post-write
+    // print + summary are honest about what's persisted.
     apply_links(&keystore, &detections)?;
+    print_detections(&detections, false);
     eprintln!(
         "Wrote {} card↔key link{} to the keystore.",
         detections.len(),
@@ -181,7 +185,6 @@ fn apply_links(keystore: &wecanencrypt::KeyStore, detections: &[CardKeyDetection
     for d in detections {
         if !info_cache.contains_key(&d.card_ident) {
             let info = get_card_details(Some(&d.card_ident))
-                .map_err(|e| anyhow!("{e}"))
                 .with_context(|| format!("failed to read card {}", d.card_ident))?;
             info_cache.insert(d.card_ident.clone(), info);
         }
@@ -193,7 +196,6 @@ fn apply_links(keystore: &wecanencrypt::KeyStore, detections: &[CardKeyDetection
             slot_str(d.slot),
             &d.slot_fingerprint,
         )
-        .map_err(|e| anyhow!("{e}"))
         .with_context(|| {
             format!(
                 "failed to write link for card {} slot {} → key {}",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -252,6 +252,21 @@ pub enum CardCommand {
         #[clap(short = 'y', long)]
         yes: bool,
     },
+
+    /// Link cards already provisioned with keys whose certs are in the keystore.
+    ///
+    /// Walks every connected card and writes a `card_keys` row for each
+    /// slot whose fingerprint matches a key in the keystore. Required for
+    /// the SSH agent to find card-backed authentication keys.
+    Link {
+        /// Print the matches that would be written and exit; touch nothing.
+        #[clap(long)]
+        dry_run: bool,
+
+        /// Restrict linking to one card. Accepts the IDENT shown by `tcli card list`.
+        #[clap(long, value_name = "IDENT")]
+        card_ident: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -372,6 +387,10 @@ pub enum Mode {
     },
     CacheClear {
         target: Option<String>,
+    },
+    CardLink {
+        dry_run: bool,
+        card_ident: Option<String>,
     },
     None,
 }
@@ -526,6 +545,13 @@ fn mode_from_card(cmd: CardCommand) -> Result<Mode, String> {
     match cmd {
         CardCommand::Status => Ok(Mode::CardStatus),
         CardCommand::List => Ok(Mode::ListCards),
+        CardCommand::Link {
+            dry_run,
+            card_ident,
+        } => Ok(Mode::CardLink {
+            dry_run,
+            card_ident,
+        }),
 
         #[cfg(feature = "experimental")]
         CardCommand::Upload {
@@ -803,6 +829,68 @@ mod tests {
     #[test]
     fn card_list_subcommand() {
         assert!(matches!(parse(&["card", "list"]), Ok(Mode::ListCards)));
+    }
+
+    #[test]
+    fn card_link_subcommand_defaults() {
+        match parse(&["card", "link"]).unwrap() {
+            Mode::CardLink {
+                dry_run,
+                card_ident,
+            } => {
+                assert!(!dry_run);
+                assert!(card_ident.is_none());
+            }
+            other => panic!(
+                "expected CardLink, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn card_link_subcommand_dry_run() {
+        match parse(&["card", "link", "--dry-run"]).unwrap() {
+            Mode::CardLink { dry_run, .. } => assert!(dry_run),
+            other => panic!(
+                "expected CardLink, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn card_link_subcommand_filter_card_ident() {
+        match parse(&["card", "link", "--card-ident", "000F:CB9A5355"]).unwrap() {
+            Mode::CardLink {
+                dry_run,
+                card_ident,
+            } => {
+                assert!(!dry_run);
+                assert_eq!(card_ident.as_deref(), Some("000F:CB9A5355"));
+            }
+            other => panic!(
+                "expected CardLink, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn card_link_subcommand_dry_run_with_card_ident() {
+        match parse(&["card", "link", "--dry-run", "--card-ident", "0006:0001"]).unwrap() {
+            Mode::CardLink {
+                dry_run,
+                card_ident,
+            } => {
+                assert!(dry_run);
+                assert_eq!(card_ident.as_deref(), Some("0006:0001"));
+            }
+            other => panic!(
+                "expected CardLink, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,7 +114,7 @@ pub enum Command {
         binary: bool,
     },
 
-    /// Create an inline (cleartext) signature.
+    /// Create an inline (cleartext) signature. Software keys only.
     SignInline {
         /// Input file. Use `-` for stdin (then `-o`/`--output` is required).
         #[clap(value_name = "FILE")]

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -539,8 +539,7 @@ mod tests {
         let outcome = DecryptVerifyOutcome::Good {
             key_info,
             verifier_fingerprint:
-                "B2D4FACE0123456789ABCDEF0123456789ABCDEF\n[GNUPG:] VALIDSIG forged"
-                    .to_string(),
+                "B2D4FACE0123456789ABCDEF0123456789ABCDEF\n[GNUPG:] VALIDSIG forged".to_string(),
         };
         let mut buf: Vec<u8> = Vec::new();
         emit_signature_status(&mut buf, &outcome).unwrap();

--- a/src/gpg/encrypt.rs
+++ b/src/gpg/encrypt.rs
@@ -452,8 +452,7 @@ mod tests {
         // signature was produced by Alice. This is the property that
         // distinguishes sign+encrypt from encrypt-only.
         let ciphertext = std::fs::read(&out_path).unwrap();
-        let bob_passphrase: libtumpa::Passphrase =
-            zeroize::Zeroizing::new("pw".to_string());
+        let bob_passphrase: libtumpa::Passphrase = zeroize::Zeroizing::new("pw".to_string());
         let store = wecanencrypt::KeyStore::open(&ks_path).unwrap();
         let result = libtumpa::decrypt::decrypt_and_verify_with_key(
             &store,
@@ -464,8 +463,7 @@ mod tests {
         .expect("decrypt+verify should succeed for sign+encrypt output");
 
         assert_eq!(
-            &*result.plaintext,
-            b"hello over signed channel",
+            &*result.plaintext, b"hello over signed channel",
             "round-tripped plaintext mismatch"
         );
         match result.outcome {

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -390,11 +390,20 @@ pub fn cmd_info(key_id: &str, keystore_path: Option<&PathBuf>) -> Result<()> {
     let (key_data, key_info) = store::resolve_signer(&keystore, key_id)?;
     print_key_info(&key_data, &key_info);
 
-    // Append "Cards:" footer with every card linked to this cert. Empty
-    // and silently skipped when the key isn't on any card. Read-only:
-    // looks at `card_keys` rows, never probes PCSC.
+    // Append "Cards:" footer with every card linked to this cert. The
+    // renderer returns an empty Vec (silent skip) when the key isn't
+    // on any card. Read-only: looks at `card_keys` rows, never probes
+    // PCSC. A DB-level failure here (locked SQLite, schema mismatch)
+    // is propagated rather than swallowed — `tcli describe` returning
+    // a misleading "no cards" footer would hide a real keystore
+    // problem.
     let assocs = libtumpa::card::link::card_associations(&keystore, &key_info.fingerprint)
-        .unwrap_or_default();
+        .with_context(|| {
+            format!(
+                "failed to load card associations for key {}",
+                key_info.fingerprint
+            )
+        })?;
     for line in crate::card_link::render_card_links_for_key(&assocs) {
         println!("{line}");
     }

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -389,6 +389,16 @@ pub fn cmd_info(key_id: &str, keystore_path: Option<&PathBuf>) -> Result<()> {
     let keystore = store::open_keystore(keystore_path)?;
     let (key_data, key_info) = store::resolve_signer(&keystore, key_id)?;
     print_key_info(&key_data, &key_info);
+
+    // Append "Cards:" footer with every card linked to this cert. Empty
+    // and silently skipped when the key isn't on any card. Read-only:
+    // looks at `card_keys` rows, never probes PCSC.
+    let assocs = libtumpa::card::link::card_associations(&keystore, &key_info.fingerprint)
+        .unwrap_or_default();
+    for line in crate::card_link::render_card_links_for_key(&assocs) {
+        println!("{line}");
+    }
+
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod cache_cmd;
+pub mod card_link;
 pub mod cli;
 pub mod gpg;
 pub mod keystore;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::io::stdout;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use tumpa_cli::{cache_cmd, keystore, pinentry, sign_cmd, ssh, store, verify_cmd};
+use tumpa_cli::{cache_cmd, card_link, keystore, pinentry, sign_cmd, ssh, store, verify_cmd};
 
 use cli::*;
 
@@ -88,6 +88,10 @@ fn main() {
         #[cfg(feature = "experimental")]
         Ok(Mode::ResetCard { card_ident }) => upload_card::cmd_reset_card(card_ident.as_deref()),
         Ok(Mode::ListCards) => tumpa_cli::list_cards::cmd_list_cards(),
+        Ok(Mode::CardLink {
+            dry_run,
+            card_ident,
+        }) => card_link::cmd_card_link(dry_run, card_ident.as_deref(), keystore_path.as_ref()),
         Ok(Mode::ShowSocket { ssh }) => {
             if ssh {
                 match tumpa_cli::agent::default_ssh_socket_path() {

--- a/src/tclig/cli.rs
+++ b/src/tclig/cli.rs
@@ -268,11 +268,9 @@ impl TryFrom<Args> for Mode {
             // sign+encrypt would change the output format the
             // user explicitly asked for.
             if value.clearsign {
-                return Err(
-                    "--clearsign cannot be combined with --encrypt; \
+                return Err("--clearsign cannot be combined with --encrypt; \
                      use --sign for sign-then-encrypt"
-                        .into(),
-                );
+                    .into());
             }
             // --digest-algo only locks the digest for the detached
             // signing path; in --encrypt mode there is no detached
@@ -281,11 +279,9 @@ impl TryFrom<Args> for Mode {
             // callers that include it as a default — better to fail
             // loudly so the caller drops the flag.
             if value.digest_algo.is_some() {
-                return Err(
-                    "--digest-algo is not supported with --encrypt; \
+                return Err("--digest-algo is not supported with --encrypt; \
                      it only locks the digest for detached signatures (-b)"
-                        .into(),
-                );
+                    .into());
             }
             let output = value.output.ok_or("Encryption requires -o/--output")?;
             let input = value.input_files.first().map(PathBuf::from);
@@ -337,11 +333,9 @@ impl TryFrom<Args> for Mode {
         // turning on --decrypt would risk confusion with --verify
         // (the detached path), so we reject loudly instead.
         if value.verify_decrypt {
-            return Err(
-                "--verify-decrypt requires --decrypt; \
+            return Err("--verify-decrypt requires --decrypt; \
                  use --verify for detached-signature verification"
-                    .into(),
-            );
+                .into());
         }
 
         // --verify
@@ -374,9 +368,7 @@ impl TryFrom<Args> for Mode {
             // be a silent no-op, which is exactly the trap a GPG
             // drop-in must avoid.
             if value.digest_algo.is_some() && shape != SignShape::Detached {
-                return Err(
-                    "--digest-algo is only supported for detached signatures (-b)".into(),
-                );
+                return Err("--digest-algo is only supported for detached signatures (-b)".into());
             }
             return Ok(Mode::Sign {
                 signer_id,
@@ -634,9 +626,7 @@ mod tests {
         .unwrap();
         match m {
             Mode::Sign {
-                shape,
-                digest_algo,
-                ..
+                shape, digest_algo, ..
             } => {
                 assert_eq!(shape, SignShape::Detached);
                 assert_eq!(digest_algo.as_deref(), Some("SHA512"));


### PR DESCRIPTION
Adds `tcli card link [--dry-run] [--card-ident IDENT]` that walks every connected OpenPGP card via libtumpa's existing `card::link::auto_detect` and writes a `card_keys` row for each slot whose fingerprint matches a key in the keystore.

Why this is needed
------------------
`tcli ssh-agent` (and `tcli agent --ssh`) enumerates SSH identities by joining `card_keys` rows against connected cards. Without rows where `slot = "authentication"` the agent advertises nothing and `ssh-add -L` prints no card-backed identities, even with the card plugged in and the auth-capable cert in the keystore. tumpa desktop builds before the `auto_link_after_upload` helper landed, and any card provisioned via `gpg keytocard` and then imported, leave the table empty. This subcommand repairs the link from the CLI without re-uploading.

Behaviour
---------
Read-only on the cards (no PIN prompts, no APDU writes), read-write on the keystore. Idempotent: the underlying `save_card_key` uses `INSERT OR REPLACE`, so re-running rewrites the same rows. Matches all slots (signature / encryption / authentication) case-insensitively. With `--card-ident` only matches on that one card are written; with no matches on the requested card, errors with a hint instead of silently no-op'ing. With no filter and no matches anywhere, prints an informational line and exits 0.

Slot strings ("signature" / "encryption" / "authentication") are pinned in a small `slot_str()` helper because the SSH agent's enumerator filters on the literal `"authentication"` value -- silent drift here would break ssh-add and git ssh-signing without a build error.