### PR TITLE
add(notify): add Linux touch-confirmation banners via notify-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +387,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -405,7 +547,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -504,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +709,12 @@ name = "crc24"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
@@ -691,6 +848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +950,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -906,6 +1082,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1145,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1075,6 +1299,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1225,6 +1462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,7 +1609,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1766,6 +2009,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +2035,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1834,6 +2098,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8146c105ae33d744e2d645f684d063b01176a99daf5986556266777b428816"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,6 +2127,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1900,6 +2184,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1960,6 +2283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,7 +2356,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2141,6 +2480,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2516,20 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "polyval"
@@ -2204,6 +2568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2607,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2811,6 +3190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,6 +3537,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3600,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -3293,7 +3714,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3302,7 +3723,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3357,7 +3778,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3377,7 +3810,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tumpa-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3390,6 +3823,7 @@ dependencies = [
  "libc",
  "libtumpa",
  "log",
+ "notify-rust",
  "p256",
  "p384",
  "p521",
@@ -3419,6 +3853,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3477,6 +3922,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -3652,6 +4108,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,9 +4150,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3688,9 +4190,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3698,9 +4216,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3709,7 +4236,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3718,7 +4254,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3754,7 +4290,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3786,6 +4322,24 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3880,6 +4434,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -3941,6 +4504,67 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
 ]
 
 [[package]]
@@ -4048,3 +4672,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow 0.7.15",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tumpa-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "OpenPGP operations and SSH agent backed by tumpa keystore."
 license = "GPL-3.0-or-later"
@@ -80,18 +80,28 @@ p521 = "0.13"
 # code can call `Utc::now()`.
 chrono = "0.4"
 
-# macOS-only: talktosc is the direct PCSC APDU sender used by
-# `card_touch::read_uif_via_talktosc`. That helper is only reachable
-# from `maybe_notify_touch`, which is itself gated on macOS — so
-# pulling talktosc on Linux/BSD would build a PCSC stack we never
-# call. Some YubiKey firmware (4.3.x and earlier) supports per-slot
-# UIF but does NOT embed the UIF tags in the Application Related
-# Data DO; openpgp-card-rs only walks ARD, so its
-# `user_interaction_flag` returns `None` on those cards. talktosc
-# lets us send `GET DATA 0xD6/0xD7/0xD8` directly and read the
-# policy bytes the card actually has.
-[target.'cfg(target_os = "macos")'.dependencies]
+# Direct PCSC APDU sender used by `card_touch::read_uif_via_talktosc`,
+# the fallback that catches per-slot UIF on YubiKey firmware 4.3.x and
+# earlier (those cards support UIF DOs but don't embed the tags in
+# Application Related Data, so openpgp-card-rs's ARD-only path returns
+# `None` for every slot). talktosc lets us send `GET DATA 0xD6/0xD7/0xD8`
+# directly and read the policy bytes the card actually has.
+#
+# Unconditional dep: the touch-banner path now runs on macOS and Linux
+# (Linux added in 0.7), and wecanencrypt's `card-pcsc` feature already
+# pulls the PCSC stack on Linux — so the only added cost on Linux is
+# `talktosc` itself + `thiserror`.
 talktosc = "0.3.0"
+
+# Linux-only: notify-rust posts the touch banner via D-Bus
+# `org.freedesktop.Notifications`. macOS uses terminal-notifier (see
+# `notify::post_macos`) because notify-rust's macOS backend posts via
+# NSUserNotification, which routes under the calling Terminal's bundle
+# identity (the exact problem the macOS comment in notify.rs documents).
+# Other Unixes / Windows: `notify::touch_prompt` is a compile-time no-op,
+# so no dep is needed.
+[target.'cfg(target_os = "linux")'.dependencies]
+notify-rust = "4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,10 +87,10 @@ chrono = "0.4"
 # `None` for every slot). talktosc lets us send `GET DATA 0xD6/0xD7/0xD8`
 # directly and read the policy bytes the card actually has.
 #
-# Unconditional dep: the touch-banner path now runs on macOS and Linux
-# (Linux added in 0.7), and wecanencrypt's `card-pcsc` feature already
-# pulls the PCSC stack on Linux — so the only added cost on Linux is
-# `talktosc` itself + `thiserror`.
+# Unconditional dep: the touch-banner path runs on both macOS and
+# Linux, and wecanencrypt's `card-pcsc` feature already pulls the
+# PCSC stack on Linux, so the only added cost on Linux is `talktosc`
+# itself + `thiserror`.
 talktosc = "0.3.0"
 
 # Linux-only: notify-rust posts the touch banner via D-Bus

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ brew install tumpa-cli
 cargo install tumpa-cli
 ```
 
+```
+# On Fedora 44/43
+sudo dnf copr enable kushal/tumpa
+sudo dnf install rust-tumpa-cli
+```
+
 Linux also needs PC/SC libraries for card support — see
 [System dependencies](#system-dependencies) below.
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ brew install tumpa-cli
 
 # Linux / from source
 cargo install tumpa-cli
-
-# On Fedora 44/43
-sudo dnf copr enable kushal/tumpa
-sudo dnf install rust-tumpa-cli
 ```
 
 Linux also needs PC/SC libraries for card support — see

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,14 +48,6 @@ stored in `~/.tumpa/keys.db`.
 Make sure `~/.cargo/bin/` is in your `PATH`.
 
 
-### On Fedora 44/43
-
-
-```
-sudo dnf copr enable kushal/tumpa
-sudo dnf install rust-tumpa-cli
-```
-
 ### Homebrew
 
 ```
@@ -114,6 +106,21 @@ runtime helpers automatically:
   ..." which appeared when we used `osascript` previously).
   Without it the banners are silently skipped; the underlying
   signing / decryption call still works.
+
+### Linux desktop notifications
+
+On Linux, smartcard touch-confirmation banners are posted directly to
+D-Bus `org.freedesktop.Notifications` via the `notify-rust` crate — no
+extra package install. Any standards-compliant notification daemon
+(gnome-shell, KDE / Plasma, Dunst, mako, xfce4-notifyd) will display
+them. Banners show `app_name = tumpa-cli`, so daemon-side filter rules
+can target that string if you want to mute or restyle them.
+
+The path is best-effort and **fail-open**: on a headless server, in a
+container, or over an SSH session with no notification daemon, the
+banner call returns an error, a `warn!` line is emitted, and the card
+operation proceeds normally. There is no separate "server build" — the
+same binary works in both environments.
 
 ### Shell completions
 

--- a/src/card_touch.rs
+++ b/src/card_touch.rs
@@ -244,8 +244,11 @@ pub(crate) fn decide_from_modes(
 ///
 /// Pass the OpenPGP card ident (e.g. `"0006:01234567"`) when known so the
 /// touch policy is queried for the exact card; pass `None` to fall back to
-/// the first enumerated card. On any failure, this is a silent no-op —
-/// notifications are best-effort UX.
+/// the first enumerated card. Best-effort and fail-open: failures inside
+/// the UIF read or the notification post never propagate, and the card
+/// op proceeds unchanged. Not silent though -- error paths and the
+/// defensive-notify branches both leave `warn!` / `info!` traces so the
+/// user can debug "why didn't I get a banner".
 ///
 /// Runs on every target. `notify::touch_prompt` handles the per-OS
 /// dispatch (terminal-notifier on macOS, notify-rust on Linux,

--- a/src/card_touch.rs
+++ b/src/card_touch.rs
@@ -1,19 +1,19 @@
-//! Decide whether a card op is going to block on a physical touch, and (on
-//! macOS) post a Notification Center banner if so.
+//! Decide whether a card op is going to block on a physical touch, and
+//! post a notification banner if so.
 //!
 //! Called from each card-aware dispatch site (sign / decrypt / sign+encrypt
 //! sign-leg / SSH auth) right after the card has been identified and before
 //! the libtumpa primitive is invoked. The libtumpa primitive opens its own
 //! PCSC transaction; we open a transient one here, query the User Interaction
 //! Flag, then drop it — there is no overlap, so no PCSC contention.
+//!
+//! Platform-dispatch for the actual banner-posting lives in `crate::notify`;
+//! this module is platform-agnostic and runs the same UIF-decision logic on
+//! macOS and Linux. On targets where `notify::touch_prompt` is a compile-time
+//! no-op (other Unix, Windows), the decision work still runs but its only
+//! side effect is the log line — harmless.
 
-// `TouchOp` is needed both on macOS (for `decide` / `maybe_notify_touch`)
-// and in the unit tests (for `decide_from_modes`). On non-macOS, non-test
-// builds neither path exists, and Linux CI runs with -D warnings, so
-// importing it unconditionally trips dead-code errors.
-#[cfg(target_os = "macos")]
 use crate::notify;
-#[cfg(any(target_os = "macos", test))]
 use crate::notify::TouchOp;
 
 pub use crate::notify::TouchOp as Op;
@@ -21,12 +21,6 @@ pub use crate::notify::TouchOp as Op;
 /// Touch-policy decision. Crate-visible so the unit tests in this
 /// module (and other tumpa-cli internals) can match on it without
 /// going through the full `maybe_notify_touch` side-effect path.
-///
-/// macOS-or-test only: only the macOS notification path consumes this,
-/// and the unit tests at the bottom of this file exercise it without
-/// hardware. On non-macOS, non-test builds it would be dead code and
-/// Linux CI runs with -D warnings.
-#[cfg(any(target_os = "macos", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Decision {
     /// Slot is `On` or `Fixed`: card will refuse the op until the user
@@ -40,7 +34,6 @@ pub(crate) enum Decision {
     NotRequired,
 }
 
-#[cfg(any(target_os = "macos", test))]
 impl Decision {
     pub(crate) fn should_notify(self) -> bool {
         matches!(self, Decision::Required | Decision::MaybeCached)
@@ -68,11 +61,6 @@ impl Decision {
 ///     failed). With a warn-level log.
 ///   - all three slots `None` (after fallback) → `NotRequired`
 ///     (older card with no UIF support — silent skip is correct).
-/// macOS-only: the only caller is the macOS-gated
-/// `maybe_notify_touch`, and the talktosc fallback path it depends on
-/// would otherwise force the PCSC stack to build on Linux/BSD for
-/// dead code.
-#[cfg(target_os = "macos")]
 pub(crate) fn decide(op: TouchOp, card_ident: Option<&str>) -> Decision {
     let modes = match wecanencrypt::card::get_touch_modes(card_ident) {
         Ok((None, None, None)) => {
@@ -112,10 +100,7 @@ pub(crate) fn decide(op: TouchOp, card_ident: Option<&str>) -> Decision {
 
 /// Map the OpenPGP card's UIF policy byte to wecanencrypt's
 /// `TouchMode`. Pure function, factored out for unit testing — the
-/// rest of the talktosc path needs real hardware. Only used by the
-/// macOS-gated `read_uif_via_talktosc` (and by tests via that path);
-/// gated to avoid a dead-code error on non-macOS, non-test builds.
-#[cfg(any(target_os = "macos", test))]
+/// rest of the talktosc path needs real hardware.
 fn touch_mode_from_policy_byte(byte: u8) -> Option<wecanencrypt::card::TouchMode> {
     use wecanencrypt::card::TouchMode;
     match byte {
@@ -151,10 +136,6 @@ fn touch_mode_from_policy_byte(byte: u8) -> Option<wecanencrypt::card::TouchMode
 ///
 /// Best-effort by design: errors are logged at warn / debug level
 /// and the caller falls through to its own None-handling.
-///
-/// macOS-only: gated alongside `decide` and the `talktosc` Cargo
-/// dependency.
-#[cfg(target_os = "macos")]
 fn read_uif_via_talktosc(
     card_ident: &str,
 ) -> Option<(
@@ -221,10 +202,7 @@ fn read_uif_via_talktosc(
 
 /// Pure decision logic, factored out for unit testing without
 /// hitting real card hardware. Takes the raw `(sig, enc, auth)` tuple
-/// from `wecanencrypt::card::get_touch_modes`. Only consumed by the
-/// macOS-gated `decide` and by the unit tests; gated to avoid a
-/// dead-code error on non-macOS, non-test builds.
-#[cfg(any(target_os = "macos", test))]
+/// from `wecanencrypt::card::get_touch_modes`.
 pub(crate) fn decide_from_modes(
     op: TouchOp,
     modes: (
@@ -269,10 +247,13 @@ pub(crate) fn decide_from_modes(
 /// the first enumerated card. On any failure, this is a silent no-op —
 /// notifications are best-effort UX.
 ///
-/// macOS-only: the underlying `notify::touch_prompt` is itself a
-/// no-op on every other platform, and the UIF / card-detail queries
-/// would cost extra PCSC traffic with no user-visible benefit.
-#[cfg(target_os = "macos")]
+/// Runs on every target. `notify::touch_prompt` handles the per-OS
+/// dispatch (terminal-notifier on macOS, notify-rust on Linux,
+/// compile-time no-op elsewhere). On targets where the post is a no-op,
+/// the UIF read still happens — its cost is a single transient PCSC
+/// transaction and the result lands in the log, which is the right
+/// trade-off for the headless / SSH case where the user may still want
+/// to debug "why didn't I get a banner".
 pub fn maybe_notify_touch(op: Op, card_ident: Option<&str>) {
     if !decide(op, card_ident).should_notify() {
         return;
@@ -289,10 +270,6 @@ pub fn maybe_notify_touch(op: Op, card_ident: Option<&str>) {
 
     notify::touch_prompt(op, serial.as_deref());
 }
-
-/// Non-macOS stub. See the macOS variant for rationale.
-#[cfg(not(target_os = "macos"))]
-pub fn maybe_notify_touch(_op: Op, _card_ident: Option<&str>) {}
 
 #[cfg(test)]
 mod tests {

--- a/src/card_touch.rs
+++ b/src/card_touch.rs
@@ -10,8 +10,8 @@
 //! Platform-dispatch for the actual banner-posting lives in `crate::notify`;
 //! this module is platform-agnostic and runs the same UIF-decision logic on
 //! macOS and Linux. On targets where `notify::touch_prompt` is a compile-time
-//! no-op (other Unix, Windows), the decision work still runs but its only
-//! side effect is the log line — harmless.
+//! no-op (other Unix, Windows), only the notification-posting part is elided;
+//! the UIF decision path still runs and may perform card/PCSC I/O (and log).
 
 use crate::notify;
 use crate::notify::TouchOp;

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -26,8 +26,9 @@
 //! never propagated — the notify path is purely UX, never load-bearing
 //! for the crypto op.
 
-/// Which slot is about to be exercised — only used to pick the verb in
-/// the notification body.
+/// Which slot is about to be exercised -- only used to pick the verb in
+/// the notification headline (macOS subtitle / Linux summary). The body
+/// holds the card identifier, not the verb.
 #[derive(Debug, Clone, Copy)]
 pub enum TouchOp {
     Sign,
@@ -35,6 +36,13 @@ pub enum TouchOp {
     Auth,
 }
 
+// `verb`, `render`, and `last_hex` are only used from the per-OS post
+// path or from the unit tests. Gating them with the same cfg that
+// guards their call sites keeps non-supported release builds free of
+// `dead_code` warnings under `-D warnings` and keeps the
+// "compile-time no-op" contract honest -- on those targets, nothing
+// here is even compiled.
+#[cfg(any(test, target_os = "macos", target_os = "linux"))]
 impl TouchOp {
     fn verb(self) -> &'static str {
         match self {
@@ -56,6 +64,7 @@ impl TouchOp {
 ///
 /// Factored out so both platform paths produce identical text, and so
 /// the rendering can be unit-tested without any system call.
+#[cfg(any(test, target_os = "macos", target_os = "linux"))]
 fn render(op: TouchOp, card_serial: Option<&str>) -> (String, String) {
     let headline = format!("Touch your card to {}", op.verb());
     let supporting = match card_serial {
@@ -68,6 +77,7 @@ fn render(op: TouchOp, card_serial: Option<&str>) -> (String, String) {
 /// Trim a long hex serial down to its last `n` characters so the
 /// notification body stays readable. Falls back to the whole string
 /// when it's already short enough.
+#[cfg(any(test, target_os = "macos", target_os = "linux"))]
 fn last_hex(s: &str, n: usize) -> String {
     let chars: Vec<char> = s.chars().collect();
     if chars.len() <= n {

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,7 +1,6 @@
-//! Best-effort macOS Notification Center banner for "touch your card now"
-//! prompts.
+//! Best-effort "touch your card now" banner.
 //!
-//! Shells out to `terminal-notifier` (Homebrew: `brew install
+//! macOS: shells out to `terminal-notifier` (Homebrew: `brew install
 //! terminal-notifier`). We used to drive `osascript -e 'display
 //! notification ...'` but that posts under the calling Terminal's bundle
 //! identity, so the user-facing notification appeared with the Terminal
@@ -12,11 +11,23 @@
 //! entry under System Settings → Notifications and the user can grant it
 //! Banner / Alert style independently of Terminal's settings.
 //!
-//! On non-macOS builds the public function compiles to a no-op so call
-//! sites don't need their own `#[cfg]` guards.
+//! Linux: posts via `notify-rust` → D-Bus `org.freedesktop.Notifications`.
+//! `zbus`'s session-bus discovery walks `DBUS_SESSION_BUS_ADDRESS` →
+//! `$XDG_RUNTIME_DIR/bus` per the D-Bus spec, so a user-systemd-started
+//! agent (with or without lingering) finds the bus without extra plumbing.
+//! On a headless server with no notification daemon, the call returns
+//! `Err`, we log a `warn!`, and the card op proceeds unchanged.
+//!
+//! Other Unix / Windows: `touch_prompt` compiles to a no-op so call sites
+//! don't need their own `#[cfg]` guards.
+//!
+//! Best-effort everywhere: any failure (terminal-notifier missing,
+//! permission denied, Focus mode, D-Bus not reachable, …) is logged but
+//! never propagated — the notify path is purely UX, never load-bearing
+//! for the crypto op.
 
-/// Which slot is about to be exercised — only used to pick the verb in the
-/// notification body.
+/// Which slot is about to be exercised — only used to pick the verb in
+/// the notification body.
 #[derive(Debug, Clone, Copy)]
 pub enum TouchOp {
     Sign,
@@ -24,7 +35,6 @@ pub enum TouchOp {
     Auth,
 }
 
-#[cfg(target_os = "macos")]
 impl TouchOp {
     fn verb(self) -> &'static str {
         match self {
@@ -35,50 +45,89 @@ impl TouchOp {
     }
 }
 
+/// Shared, pure rendering of the headline + supporting strings used in
+/// the banner.
+///
+/// Returns `(headline, supporting)`:
+///   * `headline` becomes the macOS subtitle / Linux summary — the
+///     prominent action line.
+///   * `supporting` becomes the macOS body / Linux body — the card
+///     identifier (or a generic fallback when no serial is known).
+///
+/// Factored out so both platform paths produce identical text, and so
+/// the rendering can be unit-tested without any system call.
+fn render(op: TouchOp, card_serial: Option<&str>) -> (String, String) {
+    let headline = format!("Touch your card to {}", op.verb());
+    let supporting = match card_serial {
+        Some(s) => format!("Card {}", last_hex(s, 8)),
+        None => "Waiting for touch confirmation".to_string(),
+    };
+    (headline, supporting)
+}
+
+/// Trim a long hex serial down to its last `n` characters so the
+/// notification body stays readable. Falls back to the whole string
+/// when it's already short enough.
+fn last_hex(s: &str, n: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= n {
+        s.to_string()
+    } else {
+        chars[chars.len() - n..].iter().collect()
+    }
+}
+
 /// Post a "touch your card" banner.
 ///
-/// Best-effort: any failure (terminal-notifier missing, user denied
-/// notification permission, Focus mode suppressing) is logged but
-/// never propagated — the notify path is purely UX, never load-bearing
-/// for the crypto op.
-///
-/// On macOS we run `terminal-notifier` synchronously and capture
-/// stderr so the user can see *why* a banner didn't appear when they
-/// expected one. The call site runs immediately before
-/// `pinentry::get_passphrase`, which blocks for human input anyway,
-/// so the extra ~50–150 ms wait is invisible.
+/// Best-effort: any failure is logged but never propagated. On platforms
+/// where there is no notification path (other Unix, Windows), this is a
+/// compile-time no-op.
 ///
 /// `card_serial` is rendered in the body when present; pass the
 /// user-facing serial from `wecanencrypt::card::get_card_details`
 /// (already a hex string straight from the card).
-#[cfg(target_os = "macos")]
 pub fn touch_prompt(op: TouchOp, card_serial: Option<&str>) {
-    use std::process::{Command, Stdio};
-
-    let title = "Tumpa";
-    let subtitle = format!("Touch your card to {}", op.verb());
-    let body = match card_serial {
-        Some(s) => {
-            let trimmed = last_hex(s, 8);
-            format!("Card {}", trimmed)
-        }
-        None => "Waiting for touch confirmation".to_string(),
-    };
-
+    let (headline, supporting) = render(op, card_serial);
     log::info!(
-        "posting touch banner via terminal-notifier: title={title:?} subtitle={subtitle:?} body={body:?}"
+        "touch banner: op={op:?} headline={headline:?} body={supporting:?}"
     );
 
+    #[cfg(target_os = "macos")]
+    post_macos(&headline, &supporting);
+
+    #[cfg(target_os = "linux")]
+    post_linux(&headline, &supporting);
+
+    // Other targets: deliberately no-op. `headline` / `supporting` are
+    // still computed and logged above so the trace is useful when
+    // debugging from a non-macOS, non-Linux dev box.
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (headline, supporting);
+    }
+}
+
+/// Post via `terminal-notifier` synchronously. We capture stderr so the
+/// user can see *why* a banner didn't appear when they expected one.
+/// The call site runs immediately before `pinentry::get_passphrase`,
+/// which blocks for human input anyway, so the extra ~50–150 ms wait is
+/// invisible.
+#[cfg(target_os = "macos")]
+fn post_macos(headline: &str, supporting: &str) {
+    use std::process::{Command, Stdio};
+
+    let title = "tumpa-cli";
+
     // `Command::arg` uses argv directly (no shell), so `title` /
-    // `subtitle` / `body` don't need escaping — quotes and special
+    // `headline` / `supporting` don't need escaping — quotes and special
     // characters travel as bytes.
     let result = Command::new("terminal-notifier")
         .arg("-title")
         .arg(title)
         .arg("-subtitle")
-        .arg(&subtitle)
+        .arg(headline)
         .arg("-message")
-        .arg(&body)
+        .arg(supporting)
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .stdin(Stdio::null())
@@ -107,23 +156,43 @@ pub fn touch_prompt(op: TouchOp, card_serial: Option<&str>) {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
-pub fn touch_prompt(_op: TouchOp, _card_serial: Option<&str>) {}
+/// Post via `notify-rust` → D-Bus. `urgency = Normal` and no explicit
+/// `expire_timeout` so the user's notification daemon decides how long
+/// the banner stays up. `dialog-password` is the freedesktop stock
+/// "auth-needed" icon name and is present in adwaita / breeze / papirus
+/// / numix.
+///
+/// `Notification::show()` returns a `NotificationHandle`; we drop it
+/// immediately because we don't manage its lifetime (no replace, no
+/// explicit close). On a headless server with no D-Bus session bus or no
+/// notification daemon, this returns `Err` — we warn and continue, and
+/// the card op proceeds unchanged.
+#[cfg(target_os = "linux")]
+fn post_linux(headline: &str, supporting: &str) {
+    use notify_rust::{Notification, Urgency};
 
-/// Trim a long hex serial down to its last `n` characters so the
-/// notification body stays readable. Falls back to the whole string when
-/// it's already short enough.
-#[cfg(target_os = "macos")]
-fn last_hex(s: &str, n: usize) -> String {
-    let chars: Vec<char> = s.chars().collect();
-    if chars.len() <= n {
-        s.to_string()
-    } else {
-        chars[chars.len() - n..].iter().collect()
+    let result = Notification::new()
+        .appname("tumpa-cli")
+        .summary(headline)
+        .body(supporting)
+        .icon("dialog-password")
+        .urgency(Urgency::Normal)
+        .show();
+
+    match result {
+        Ok(_handle) => {
+            log::info!("notify-rust posted touch banner ok");
+        }
+        Err(e) => {
+            log::warn!(
+                "could not post touch banner via notify-rust ({e}); \
+                 card op proceeds normally"
+            );
+        }
     }
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -135,5 +204,24 @@ mod tests {
     #[test]
     fn last_hex_keeps_short_serial() {
         assert_eq!(last_hex("ABCD", 8), "ABCD");
+    }
+
+    #[test]
+    fn render_uses_action_verb_in_headline() {
+        let (headline, body) = render(TouchOp::Sign, Some("0123456789ABCDEF"));
+        assert_eq!(headline, "Touch your card to sign");
+        assert_eq!(body, "Card 89ABCDEF");
+
+        let (headline, _) = render(TouchOp::Decrypt, None);
+        assert_eq!(headline, "Touch your card to decrypt");
+
+        let (headline, _) = render(TouchOp::Auth, None);
+        assert_eq!(headline, "Touch your card to authenticate");
+    }
+
+    #[test]
+    fn render_without_serial_uses_fallback_body() {
+        let (_, body) = render(TouchOp::Sign, None);
+        assert_eq!(body, "Waiting for touch confirmation");
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -81,29 +81,34 @@ fn last_hex(s: &str, n: usize) -> String {
 ///
 /// Best-effort: any failure is logged but never propagated. On platforms
 /// where there is no notification path (other Unix, Windows), this is a
-/// compile-time no-op.
+/// true compile-time no-op -- the function does not even render strings
+/// or emit a log line; nothing happens at the call site.
 ///
 /// `card_serial` is rendered in the body when present; pass the
 /// user-facing serial from `wecanencrypt::card::get_card_details`
 /// (already a hex string straight from the card).
 pub fn touch_prompt(op: TouchOp, card_serial: Option<&str>) {
-    let (headline, supporting) = render(op, card_serial);
-    log::info!(
-        "touch banner: op={op:?} headline={headline:?} body={supporting:?}"
-    );
+    // Single `info!` line per banner attempt lives here in the
+    // dispatcher; the per-backend post functions log only `debug!` on
+    // success and `warn!` on failure so a successful run produces one
+    // info line per touch-required op, not two.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let (headline, supporting) = render(op, card_serial);
+        log::info!(
+            "touch banner: op={op:?} headline={headline:?} body={supporting:?}"
+        );
 
-    #[cfg(target_os = "macos")]
-    post_macos(&headline, &supporting);
+        #[cfg(target_os = "macos")]
+        post_macos(&headline, &supporting);
 
-    #[cfg(target_os = "linux")]
-    post_linux(&headline, &supporting);
+        #[cfg(target_os = "linux")]
+        post_linux(&headline, &supporting);
+    }
 
-    // Other targets: deliberately no-op. `headline` / `supporting` are
-    // still computed and logged above so the trace is useful when
-    // debugging from a non-macOS, non-Linux dev box.
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
-        let _ = (headline, supporting);
+        let _ = (op, card_serial);
     }
 }
 
@@ -135,7 +140,7 @@ fn post_macos(headline: &str, supporting: &str) {
 
     match result {
         Ok(out) if out.status.success() => {
-            log::info!("terminal-notifier posted touch banner ok");
+            log::debug!("terminal-notifier posted touch banner ok");
         }
         Ok(out) => {
             let stderr = String::from_utf8_lossy(&out.stderr);
@@ -181,7 +186,7 @@ fn post_linux(headline: &str, supporting: &str) {
 
     match result {
         Ok(_handle) => {
-            log::info!("notify-rust posted touch banner ok");
+            log::debug!("notify-rust posted touch banner ok");
         }
         Err(e) => {
             log::warn!(


### PR DESCRIPTION
Mirrors the existing macOS terminal-notifier path so Linux users get the same "Touch your card to <verb>" banner whenever a card op is about to block on a physical touch. Best-effort and fail-open: on a headless server, in a Docker container, or over an SSH session with no notification daemon, the post call returns Err, a warn line is emitted, and the card operation proceeds normally. There is no separate "server build" -- the same binary works in both environments.

Cargo.toml
----------
* Move talktosc from [target.'cfg(target_os = "macos")'.dependencies] to unconditional [dependencies]. The UIF-decision path (decide / read_uif_via_talktosc) now runs on macOS and Linux, and Linux already has the PCSC stack via wecanencrypt's card-pcsc feature, so the only added compile cost on Linux is talktosc itself plus thiserror (already a transitive dep).
* Add [target.'cfg(target_os = "linux")'.dependencies] notify-rust = "4". macOS is excluded because notify-rust's macOS backend posts via NSUserNotification, which routes under the calling Terminal's bundle identity -- the exact problem the existing terminal-notifier comment documents. Other Unix and Windows builds compile out the post entirely, so no dep is needed there.
* Drop the now-empty [target.'cfg(target_os = "macos")'.dependencies] block.