### PR TITLE
feat(tcli): add encrypt/decrypt subcommands; bump to wecanencrypt 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "libtumpa"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b82b6601e626183aae808e2afed5b10946a5c60c5a7bd8a08950c115349ef99"
+checksum = "9fa3e607076d25df6017f2c01c125df7dfc71b6abc24f7f6bb691ceff45c63fe"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3810,7 +3810,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tumpa-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4066,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "wecanencrypt"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0703345f40fd973402b286882d994199456dfd2251c8d375fe41bd856a92b6"
+checksum = "b5e04bea01ff82b46516374ea38a36b6edac3fb9d9fdba9b1ba62eb027cd556b"
 dependencies = [
  "aes",
  "aes-kw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tumpa-cli"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "OpenPGP operations and SSH agent backed by tumpa keystore."
 license = "GPL-3.0-or-later"
@@ -47,9 +47,11 @@ experimental = []
 [dependencies]
 # Keep this on a wecanencrypt release that ships the Curve25519 `0x40`
 # prefix + (X25519, X25519) match arm needed by Nitrokey 3
-# (opcard-rs >= 1.5) ECC card uploads.
-wecanencrypt = { version = "0.15.0", features = ["keystore", "card-pcsc", "network"] }
-libtumpa = { version = "0.3.2", features = ["card", "network"] }
+# (opcard-rs >= 1.5) ECC card uploads. 0.16.2 is the release whose
+# encrypt / decrypt surface backs the human-facing `tcli encrypt` /
+# `tcli decrypt` subcommands (see ADR 0010).
+wecanencrypt = { version = "0.16.2", features = ["keystore", "card-pcsc", "network"] }
+libtumpa = { version = "0.4.2", features = ["card", "network"] }
 # Must match wecanencrypt's pgp dependency exactly -- both crates parse
 # detached signatures using pgp::composed::DetachedSignature, and a version
 # mismatch could cause parser disagreement (see verify.rs dual-parse note).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For detailed usage instructions, see the
 - **password-store (`pass`) support** -- works as a drop-in GPG replacement for `pass`
 - **Browser extension support** -- [PassFF](https://github.com/passff/passff) and [Browserpass](https://github.com/browserpass/browserpass-extension) work via the `gpg2 -> tclig` symlink (ciphertext on stdin via `-`, `--debug` flag accepted)
 - **`tpass`** -- native password-store replacement, no GPG dependency
-- **OpenPGP card support** -- cards are tried first for signing, decryption, and SSH auth. Tested against **Yubikey 4/5** (RSA 2048/4096, NIST P-256/P-384; Curve25519 on firmware ≥ 5.2.3) and **Nitrokey 3** (RSA and `Cv25519Modern` — Ed25519 + X25519 per RFC 9580). Nitrokey rejects legacy `Cv25519` (EdDSALegacy + ECDH/Curve25519) along with `Ed448` and `X448` keys at upload time
+- **OpenPGP card support** -- cards are tried first for signing, decryption, and SSH auth. Tested against **YubiKey 4/5** (RSA 2048/4096, NIST P-256/P-384; Curve25519 on firmware ≥ 5.2.3) and **Nitrokey 3** (RSA and `Cv25519Modern` — Ed25519 + X25519 per RFC 9580). Nitrokey rejects legacy `Cv25519` (EdDSALegacy + ECDH/Curve25519) along with `Ed448` and `X448` keys at upload time
 - **Unified agent** -- caches passphrases for GPG operations + optional SSH agent
 - **Key management** -- import, export, search, delete, and fetch keys via WKD
 - **SSH agent** -- serve authentication subkeys from the keystore and connected cards
@@ -91,7 +91,7 @@ decryption to the card.
 
 ```
 tcli describe <FINGERPRINT>   # details for the imported key
-tcli link card                # links the imported public key(2) with the secret key on your Yubikey
+tcli card link                # links the imported public key with the secret key on your YubiKey
 tcli card status              # connected cards, serial, PIN retries
 ```
 
@@ -112,8 +112,8 @@ git config --global commit.gpgsign true
 ```
 setup-tumpa-agent
 ```
-(You might need to unplug/replug your Yubikey, 
-on order for the tumpa agent to be able to find it)
+(You might need to unplug/replug your YubiKey,
+in order for the tumpa agent to be able to find it)
 
 This installs `~/Library/LaunchAgents/in.kushaldas.tumpa.agent.plist`
 into the Aqua GUI session and bootstraps it. It also stops and removes

--- a/docs/adr/0010-tcli-encrypt-decrypt-subcommands.md
+++ b/docs/adr/0010-tcli-encrypt-decrypt-subcommands.md
@@ -1,0 +1,255 @@
+# ADR 0010: `tcli encrypt` / `tcli decrypt` Subcommands
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-22
+
+## Context
+
+Through 0.6.x, the only way to encrypt or decrypt from the shell was
+the GPG drop-in binary `tclig`:
+
+```
+tclig -e -r <FP> -o secret.gpg document.txt
+tclig -d secret.gpg
+```
+
+`tclig` exists to be invoked *by other programs* — git, `pass`, and any
+other consumer that shells out to `gpg` with `gpg`-shape flags (see
+ADR 0005). Its grammar, its `[GNUPG:]` status lines on stderr, and its
+silent acceptance of compat no-ops (`--batch`, `--no-encrypt-to`, …)
+are all there to satisfy machine callers, not humans.
+
+The human-facing binary `tcli` already covered the *signing* side of
+the same split: `tcli sign`, `tcli sign-inline`, and `tcli verify` are
+the human verbs, while `tclig -bsau` / `tclig --verify` are the
+machine forms (ADR 0009). Encryption and decryption were the only
+cryptographic operations with no human-facing verb — a user who wanted
+to encrypt a file to a colleague had to drop down to the GPG-shape
+binary and remember `-e -r … -a -o …`.
+
+This was an inconsistency, not just a missing convenience:
+
+1. **The split was advertised but incomplete.** `docs/usage.md` and
+   `--help` present `tcli` as the human UI and `tclig` as the GPG
+   drop-in, yet directed users to `tclig` for the single most common
+   non-signing operation.
+
+2. **`tclig`'s ergonomics are wrong for humans.** It emits no
+   "wrote ciphertext to X" confirmation, defaults to binary output
+   (humans usually want armored), requires `-o` for the common case,
+   and prints `INV_RECP` machine status lines instead of a readable
+   "no key for X" message.
+
+3. **The crypto core already existed.** `gpg::encrypt` and
+   `gpg::decrypt` already implement multi-recipient encryption,
+   card-first sign-then-encrypt dispatch, card-first decryption with
+   software fallback, pinentry prompting, and `0600` output
+   permissions. Only a human-facing wrapper was missing.
+
+The release that introduces these subcommands also moves the crate
+onto **wecanencrypt 0.16.2** (from 0.15.0) and **libtumpa 0.4.2**
+(from 0.3.2). 0.16.2 is the wecanencrypt release whose encrypt /
+decrypt surface (`encrypt_bytes_to_multiple`,
+`sign_and_encrypt_to_multiple`, the card `sign_and_encrypt_*` /
+`decrypt_and_verify_*` entry points) is what these wrappers build on.
+
+## Decision
+
+Add two human-facing subcommands to `tcli`, mirroring the
+`tcli sign` / `tcli verify` precedent.
+
+### Command shape
+
+```
+tcli encrypt <FILE> -r <FP|KEYID|EMAIL>... [--sign-with <ID>] [--binary] [-o OUT]
+tcli decrypt <FILE> [-o OUT]
+```
+
+- `encrypt` requires at least one `-r`/`--recipient` (clap `required =
+  true`). The flag is repeatable for multiple recipients, matching
+  `gpg -r` and `tclig -r`.
+- `encrypt` defaults to **ASCII-armored** output written to a sibling
+  `<FILE>.asc`. `--binary` switches to binary OpenPGP written to
+  `<FILE>.gpg`. `-o PATH` overrides the destination; `-o -` writes to
+  stdout. `<FILE> = -` reads plaintext from stdin and then requires
+  `-o` (there is no input filename to derive a default from).
+- `--sign-with <ID>` produces a single sign-then-encrypt message
+  (one-pass-signature + literal + signature, the same packet shape as
+  `gpg --sign --encrypt`). The signing leg is card-first (a connected
+  card holding the signer's key signs on-card), software secret key
+  with passphrase as fallback.
+- `decrypt` writes plaintext to **stdout** by default; `-o PATH` writes
+  a file with `0600` permissions. `<FILE> = -` reads ciphertext from
+  stdin. Decryption is card-first (a connected card holding the
+  decryption subkey), software secret key as fallback.
+
+### Specific design decisions
+
+**1. Reuse the `gpg::*` crypto core; do not reimplement.** This is the
+same blast-radius bound ADR 0009 decision 9 applied to the subcommand
+redesign: the parsing/UI layer is new, the secret-handling code is
+not. To make `gpg::encrypt` reusable from a caller that picks its own
+destination (sibling file *or* stdout), the core was split into two
+public helpers: `prepare_recipients` resolves recipients (emitting any
+`INV_RECP` status lines) and `encrypt_bytes_prepared` runs the
+card-first sign-then-encrypt dispatch and **returns** the ciphertext
+instead of writing a fixed path. The GPG-shape `encrypt_with_status`
+now calls `prepare_recipients` then `encrypt_bytes_prepared`, so
+`tclig` behaviour is byte-for-byte unchanged. The split also lets the
+human-facing `tcli encrypt` resolve recipients (and fail on an unknown
+one) *before* it reads plaintext, so a bad recipient never blocks on
+stdin; that path passes a sink for the status writer because
+`INV_RECP` is a machine protocol, not human output. `tcli decrypt`
+calls `gpg::decrypt::decrypt` directly — that function already takes an
+`Option<output>` and writes stdout or a `0600` file, exactly the human
+shape.
+
+**2. Armored by default, `--binary` to opt out.** This inverts
+`tclig`'s default (binary, `-a` to armor). A human encrypting a file
+to email or paste it wants armored text far more often than a binary
+blob; `tcli sign` already defaults to armored `.asc` for the same
+reason. The `--binary` flag name matches `tcli sign --binary` /
+`tcli export --binary`, so the modifier reads the same across every
+`tcli` verb.
+
+**3. Sibling-file defaults: `.asc` armored, `.gpg` binary.** Mirrors
+GnuPG's own sibling conventions and `tcli sign`'s `<FILE>.asc` /
+`<FILE>.sig` defaults. The destination logic (`encrypt_destination`)
+is a near-copy of `sign_cmd::sign_destination`, deliberately, so the
+two human verbs derive output paths identically.
+
+**4. `--sign-with`, not `--signer`.** `tcli sign` uses `--signer` for
+"the key that signs". For `encrypt` the signing key is a *secondary*,
+optional role layered onto encryption, so the flag is named for what
+it does to the message (`--sign-with`) rather than reusing `--signer`,
+which would read as "the primary subject of the command". The value
+grammar (fingerprint / key ID / email) is identical.
+
+**5. `decrypt` does not emit human signature status.** When the
+payload is a sign-then-encrypt message, `tcli decrypt` recovers the
+plaintext but does not currently print "Good signature from X". The
+GPG-shape `gpg::decrypt::decrypt_and_verify` does surface the inner
+signature, but only as `[GNUPG:]` machine lines. A human-readable
+decrypt-and-report-signature path (the decrypt analogue of
+`tcli verify`) is deferred to a follow-up rather than shipped half-
+formed here. `tcli decrypt` is scoped to "recover the plaintext";
+verifying a signature is `tcli verify`'s job.
+
+**6. No new flag at the parent level.** Like every other `tcli`
+subcommand, `encrypt`/`decrypt` inherit only the global
+`--keystore`/`TUMPA_KEYSTORE`. No operation-specific flag is hoisted
+to the top level.
+
+## Consequences
+
+### Positive
+
+- **The human/machine split is now complete.** Every cryptographic
+  operation has a human verb on `tcli` and a GPG-shape form on
+  `tclig`: sign/verify (ADR 0009) and now encrypt/decrypt. The
+  documentation no longer has to send `tcli` users to `tclig` for a
+  daily operation.
+
+- **Better defaults for interactive use.** Armored output, a derived
+  sibling path, a "wrote ciphertext to X" confirmation, and a
+  readable error when a recipient has no key — none of which `tclig`
+  offers, because `tclig` is tuned for machine callers.
+
+- **Card-first parity for free.** Because the wrappers reuse the
+  `gpg::*` core, `tcli encrypt --sign-with <card-key>` and
+  `tcli decrypt` of a message addressed to a card subkey get the same
+  YubiKey/Nitrokey dispatch as the `tclig` path, with no duplicated
+  card code.
+
+- **Bounded blast radius.** The only change to existing crypto code is
+  the split of `prepare_recipients` + `encrypt_bytes_prepared` out of
+  `encrypt_with_status`; all
+  existing `gpg::encrypt` tests still exercise `encrypt_with_status`
+  and pass unchanged.
+
+### Negative
+
+- **Two grammars for encrypt/decrypt, like sign/verify before it.**
+  Developers and power users now have `tcli encrypt` *and* `tclig -e`,
+  with different defaults (armored vs. binary). This is the same cost
+  ADR 0009 accepted for the verb split; it is the price of keeping
+  `tclig` a faithful `gpg` drop-in while giving humans good
+  ergonomics.
+
+- **`tcli decrypt` is silent about inner signatures.** A user who
+  decrypts a signed-and-encrypted message gets the plaintext but no
+  signature confirmation, which a GnuPG user might expect from a
+  single `gpg -d`. Mitigated by decision 5's scoping and the deferred
+  follow-up; the message can still be verified explicitly.
+
+- **`--sign-with` vs. `--signer` asymmetry.** The signing key is named
+  `--signer` on `tcli sign` but `--sign-with` on `tcli encrypt`. The
+  distinction is deliberate (decision 4) but is one more thing to
+  remember.
+
+## Alternatives Considered
+
+### Point `tcli encrypt` users at `tclig`
+
+Add no new subcommand; document `tclig -e` / `tclig -d` as the way to
+encrypt from `tcli`. Cheapest. Rejected: it cements the
+inconsistency — humans would use `tcli` for everything except the one
+operation that drops to the machine binary — and forces
+human-hostile defaults (binary output, mandatory `-o`, `INV_RECP`
+lines) on interactive users.
+
+### One `tcli crypt` subcommand with a direction flag
+
+A single verb (`tcli crypt --encrypt` / `--decrypt`) was considered.
+Rejected: it does not match the existing `tcli sign` / `tcli verify`
+shape (two verbs, not one verb with a mode flag), and the flag sets
+for the two directions barely overlap (`-r`/`--sign-with`/`--binary`
+are encrypt-only), so a single command would carry flags that are
+errors half the time — exactly the silently-ignored-modifier footgun
+ADR 0009 set out to remove.
+
+### Reuse `--signer` for the signing key on `encrypt`
+
+Considered for symmetry with `tcli sign --signer`. Rejected per
+decision 4: on `encrypt`, signing is an optional secondary role, and
+`--sign-with` reads more clearly as "additionally sign with" than
+`--signer` would.
+
+### Make `tcli decrypt` verify and report the inner signature
+
+Considered shipping the decrypt-and-report-signature path now, so
+`tcli decrypt` of a signed+encrypted message prints "Good signature
+from X" like `tcli verify` does for detached/inline signatures.
+Deferred (decision 5): doing it well means a human-shape translation
+of the inner-signature outcome (Good / Bad / Unsigned / UnknownKey)
+that `gpg::decrypt` currently only emits as `[GNUPG:]` lines, and
+shipping a half-formed version is worse than scoping `decrypt` to
+plaintext recovery for now.
+
+## Follow-ups
+
+- Add a human-readable inner-signature report to `tcli decrypt` (the
+  decrypt analogue of `tcli verify`), translating
+  `DecryptVerifyOutcome` into the same "Good signature from … / BAD
+  signature / Unknown signer" lines `verify_cmd` prints. Tracked from
+  decision 5.
+- When shell completions are regenerated, confirm the new `encrypt` /
+  `decrypt` subcommands and their flags appear (clap-generated for
+  `tcli`, so this is automatic, but worth a spot-check).
+
+## References
+
+- ADR 0005: Split GPG-compat Flags into a Separate `tclig` Binary
+  (parent decision: human `tcli` vs. machine `tclig`).
+- ADR 0009: `tcli` Subcommand Grammar (establishes the verb shape and
+  the "UI layer changes, secret-side code does not" blast-radius
+  bound that this ADR follows for encrypt/decrypt).
+- `src/gpg/encrypt.rs` (`prepare_recipients` + `encrypt_bytes_prepared`
+  shared core),
+  `src/gpg/decrypt.rs` (`decrypt`), `src/encrypt_cmd.rs`,
+  `src/decrypt_cmd.rs` (the human-facing wrappers).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -774,6 +774,57 @@ Both commands read the same `~/.password-store/` directory and the same
 
 ## Encryption and decryption
 
+There are two ways to encrypt and decrypt from the shell:
+
+- **`tcli encrypt` / `tcli decrypt`** — the human-facing verbs. Armored
+  output by default, a derived sibling output path, and readable
+  status messages. Use these interactively.
+- **`tclig -e` / `tclig -d`** — the GPG drop-in. Same flags `gpg`
+  accepts; binary output by default. Use these in scripts and from
+  programs that already speak `gpg`.
+
+See [ADR 0010](adr/0010-tcli-encrypt-decrypt-subcommands.md) for the
+split rationale.
+
+### Encrypting and decrypting with `tcli`
+
+Encrypt a file to a recipient (default output is `<FILE>.asc`,
+ASCII-armored):
+
+```
+tcli encrypt document.txt -r <FINGERPRINT>
+# wrote document.txt.asc
+```
+
+Multiple recipients (any of them can decrypt), binary output, or a
+custom destination:
+
+```
+tcli encrypt data.txt -r <FP1> -r <FP2> -r <FP3>
+tcli encrypt document.txt -r <FP> --binary           # writes document.txt.gpg
+tcli encrypt document.txt -r <FP> -o shared.asc
+echo "secret" | tcli encrypt - -r <FP> -o secret.asc # stdin needs -o
+```
+
+Sign and encrypt in one message (card-first signing, software
+fallback):
+
+```
+tcli encrypt document.txt -r <RECIPIENT_FP> --sign-with <YOUR_FP>
+```
+
+Decrypt to stdout (default) or to a `0600` file. A connected OpenPGP
+card holding the decryption key is tried first, then a software secret
+key from the keystore:
+
+```
+tcli decrypt secret.asc                 # plaintext to stdout
+tcli decrypt secret.asc -o document.txt # writes a 0600 file
+cat secret.asc | tcli decrypt -         # ciphertext from stdin
+```
+
+### Encrypting and decrypting with `tclig`
+
 `tclig` is the GPG drop-in, so encryption and decryption from the
 shell use the same flags `gpg` accepts.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,6 +129,49 @@ pub enum Command {
         output: Option<PathBuf>,
     },
 
+    /// Encrypt FILE to one or more recipients (default ASCII-armored).
+    ///
+    /// Default output is `<FILE>.asc` (or `<FILE>.gpg` with --binary).
+    /// Pass `--sign-with` to produce a single sign-then-encrypt message
+    /// (card-first signing, software fallback).
+    Encrypt {
+        /// Input file. Use `-` for stdin (then `-o`/`--output` is required).
+        #[clap(value_name = "FILE")]
+        input: PathBuf,
+
+        /// Recipient: fingerprint, key ID, or exact email. Repeatable.
+        #[clap(
+            short = 'r',
+            long = "recipient",
+            value_name = "FP|KEYID|EMAIL",
+            required = true
+        )]
+        recipients: Vec<String>,
+
+        /// Also sign the message with this key (sign-then-encrypt).
+        #[clap(long, value_name = "FP|KEYID|EMAIL")]
+        sign_with: Option<String>,
+
+        /// Output file. Defaults to `<FILE>.asc` (or `<FILE>.gpg` with --binary).
+        #[clap(short = 'o', long)]
+        output: Option<PathBuf>,
+
+        /// Binary output instead of ASCII-armored.
+        #[clap(long)]
+        binary: bool,
+    },
+
+    /// Decrypt FILE (card first, then software key). Plaintext to stdout.
+    Decrypt {
+        /// Input file. Use `-` for stdin.
+        #[clap(value_name = "FILE")]
+        input: PathBuf,
+
+        /// Output file. Defaults to stdout (mode 0600 when a file).
+        #[clap(short = 'o', long)]
+        output: Option<PathBuf>,
+    },
+
     /// Verify a signature on FILE.
     Verify {
         /// Input file. Use `-` for stdin (requires --signature).
@@ -380,6 +423,17 @@ pub enum Mode {
         with_key: String,
         output: Option<PathBuf>,
     },
+    Encrypt {
+        input: PathBuf,
+        recipients: Vec<String>,
+        sign_with: Option<String>,
+        binary: bool,
+        output: Option<PathBuf>,
+    },
+    Decrypt {
+        input: PathBuf,
+        output: Option<PathBuf>,
+    },
     Verify {
         input: PathBuf,
         signature: Option<PathBuf>,
@@ -490,6 +544,30 @@ fn mode_from_subcommand(cmd: Command) -> Result<Mode, String> {
                 output,
             })
         }
+
+        Command::Encrypt {
+            input,
+            recipients,
+            sign_with,
+            output,
+            binary,
+        } => {
+            if is_stdio(&input) && output.is_none() {
+                return Err(
+                    "encrypt reading from stdin requires -o/--output (no input file to derive a default path from)"
+                        .to_string(),
+                );
+            }
+            Ok(Mode::Encrypt {
+                input,
+                recipients,
+                sign_with,
+                binary,
+                output,
+            })
+        }
+
+        Command::Decrypt { input, output } => Ok(Mode::Decrypt { input, output }),
 
         Command::Verify {
             input,
@@ -817,6 +895,137 @@ mod tests {
     fn verify_stdin_requires_signature_subcommand() {
         let err = parse(&["verify", "-"]).unwrap_err();
         assert!(err.contains("--signature"), "got: {err}");
+    }
+
+    // ----- encrypt / decrypt -----
+
+    #[test]
+    fn encrypt_subcommand_single_recipient_armored_default() {
+        match parse(&["encrypt", "msg.txt", "-r", "alice@example.com"]).unwrap() {
+            Mode::Encrypt {
+                input,
+                recipients,
+                sign_with,
+                binary,
+                output,
+            } => {
+                assert_eq!(input, PathBuf::from("msg.txt"));
+                assert_eq!(recipients, vec!["alice@example.com".to_string()]);
+                assert!(sign_with.is_none());
+                assert!(!binary, "armored is the default");
+                assert!(output.is_none());
+            }
+            other => panic!("expected Encrypt, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn encrypt_subcommand_multiple_recipients_repeatable() {
+        match parse(&[
+            "encrypt",
+            "msg.txt",
+            "-r",
+            "alice@example.com",
+            "--recipient",
+            "bob@example.com",
+        ])
+        .unwrap()
+        {
+            Mode::Encrypt { recipients, .. } => {
+                assert_eq!(
+                    recipients,
+                    vec![
+                        "alice@example.com".to_string(),
+                        "bob@example.com".to_string()
+                    ]
+                );
+            }
+            other => panic!("expected Encrypt, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn encrypt_subcommand_requires_a_recipient() {
+        let err = parse(&["encrypt", "msg.txt"]).unwrap_err();
+        assert!(
+            err.contains("--recipient") || err.contains("required"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn encrypt_subcommand_sign_with_and_binary_thread_through() {
+        match parse(&[
+            "encrypt",
+            "msg.txt",
+            "-r",
+            "alice@example.com",
+            "--sign-with",
+            "bob@example.com",
+            "--binary",
+            "-o",
+            "out.gpg",
+        ])
+        .unwrap()
+        {
+            Mode::Encrypt {
+                sign_with,
+                binary,
+                output,
+                ..
+            } => {
+                assert_eq!(sign_with.as_deref(), Some("bob@example.com"));
+                assert!(binary);
+                assert_eq!(output.as_deref(), Some(std::path::Path::new("out.gpg")));
+            }
+            other => panic!("expected Encrypt, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn encrypt_stdin_requires_output_subcommand() {
+        let err = parse(&["encrypt", "-", "-r", "alice@example.com"]).unwrap_err();
+        assert!(err.contains("requires -o/--output"), "got: {err}");
+    }
+
+    #[test]
+    fn encrypt_stdin_with_output_is_ok() {
+        match parse(&["encrypt", "-", "-r", "alice@example.com", "-o", "ct.asc"]).unwrap() {
+            Mode::Encrypt { input, output, .. } => {
+                assert_eq!(input, PathBuf::from("-"));
+                assert_eq!(output.as_deref(), Some(std::path::Path::new("ct.asc")));
+            }
+            other => panic!("expected Encrypt, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn decrypt_subcommand_defaults_to_stdout() {
+        match parse(&["decrypt", "msg.asc"]).unwrap() {
+            Mode::Decrypt { input, output } => {
+                assert_eq!(input, PathBuf::from("msg.asc"));
+                assert!(output.is_none(), "no -o means stdout");
+            }
+            other => panic!("expected Decrypt, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn decrypt_subcommand_with_output_file() {
+        match parse(&["decrypt", "msg.asc", "-o", "plain.txt"]).unwrap() {
+            Mode::Decrypt { output, .. } => {
+                assert_eq!(output.as_deref(), Some(std::path::Path::new("plain.txt")));
+            }
+            other => panic!("expected Decrypt, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn decrypt_subcommand_reads_stdin() {
+        match parse(&["decrypt", "-"]).unwrap() {
+            Mode::Decrypt { input, .. } => assert_eq!(input, PathBuf::from("-")),
+            other => panic!("expected Decrypt, got {:?}", std::mem::discriminant(&other)),
+        }
     }
 
     // ----- card / socket / agent / ssh-agent / ssh-export / completions -----

--- a/src/decrypt_cmd.rs
+++ b/src/decrypt_cmd.rs
@@ -1,0 +1,64 @@
+//! `tcli decrypt` implementation.
+//!
+//! Human-shape decrypt command. The GPG-shape decrypt used by `tclig`
+//! lives in `gpg::decrypt` and stays unchanged; this module reuses its
+//! `decrypt` core (recipient inspection, card-first then software
+//! dispatch, pinentry prompts, output `0600` permissions) and adds a
+//! human-facing status message.
+//!
+//! ## Output rules
+//!
+//! - `tcli decrypt FILE`: plaintext goes to stdout by default.
+//! - `-o`/`--output` writes to a file (mode `0600` on Unix).
+//! - `FILE = -` reads ciphertext from stdin.
+//!
+//! Card priority matches signing: a connected OpenPGP card holding the
+//! decryption subkey is tried first, then a software secret key from the
+//! keystore (with passphrase).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::cli::is_stdio;
+use crate::gpg;
+
+/// `tcli decrypt FILE [-o OUT]`.
+pub fn cmd_decrypt(
+    input: &Path,
+    output: Option<&PathBuf>,
+    keystore_path: Option<&PathBuf>,
+) -> Result<()> {
+    let output = decrypt_output_destination(output);
+
+    // gpg::decrypt::decrypt owns the card-first / software-fallback
+    // dispatch, the pinentry prompts, and the output write (including the
+    // 0600 permission tightening when writing to a file).
+    gpg::decrypt::decrypt(input, output, keystore_path)?;
+
+    if let Some(path) = output {
+        eprintln!("tcli: Wrote plaintext to {}", path.display());
+    }
+    Ok(())
+}
+
+fn decrypt_output_destination(output: Option<&PathBuf>) -> Option<&PathBuf> {
+    output.filter(|path| !is_stdio(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dash_output_means_stdout() {
+        let dash = PathBuf::from("-");
+        assert!(decrypt_output_destination(Some(&dash)).is_none());
+    }
+
+    #[test]
+    fn explicit_output_path_is_preserved() {
+        let path = PathBuf::from("plain.txt");
+        assert_eq!(decrypt_output_destination(Some(&path)), Some(&path));
+    }
+}

--- a/src/encrypt_cmd.rs
+++ b/src/encrypt_cmd.rs
@@ -1,0 +1,288 @@
+//! `tcli encrypt` implementation.
+//!
+//! Human-shape encrypt command. The GPG-shape encrypt used by `tclig`
+//! lives in `gpg::encrypt`; this module reuses its
+//! `prepare_recipients` + `encrypt_bytes_prepared` core (recipient
+//! resolution and the card-first sign-then-encrypt dispatch) and adds
+//! the human-facing destination handling and status messages. The
+//! machine-shape `INV_RECP` status lines are suppressed here.
+//!
+//! ## Output rules
+//!
+//! - `tcli encrypt FILE -r REC`: default output is `<FILE>.asc`
+//!   (ASCII armored). `--binary` switches the default to `<FILE>.gpg`
+//!   (binary OpenPGP).
+//! - `-o`/`--output` overrides the destination. `-` writes to stdout.
+//! - `FILE = -` reads from stdin (caller must also pass `-o`).
+//! - `--sign-with ID` produces a single sign-then-encrypt message; the
+//!   signing leg is card-first (YubiKey/Nitrokey), software fallback.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+use crate::cli::is_stdio;
+use crate::gpg;
+
+/// `tcli encrypt FILE -r REC... [--sign-with ID] [--binary] [-o OUT]`.
+pub fn cmd_encrypt(
+    input: &Path,
+    recipients: &[String],
+    sign_with: Option<&str>,
+    binary: bool,
+    output: Option<&PathBuf>,
+    keystore_path: Option<&PathBuf>,
+) -> Result<()> {
+    let armor = !binary;
+
+    // Validate the output destination first, then resolve recipients —
+    // both before reading plaintext. So a stdin-without-`-o` mistake or
+    // an unknown recipient fails fast, without consuming stdin or doing
+    // any encryption work that would then be thrown away. INV_RECP status
+    // lines are a machine protocol for `tclig`/PGP-MIME callers; the
+    // human path discards them (sink) and relies on the returned error,
+    // which names every unusable recipient. The card-first sign+encrypt
+    // dispatch stays in the shared GPG encryption core.
+    let dest = encrypt_destination(input, output, binary)?;
+    let prepared = gpg::encrypt::prepare_recipients(recipients, keystore_path, std::io::sink())?;
+    let plaintext = read_input(input)?;
+    let ciphertext = gpg::encrypt::encrypt_bytes_prepared(&plaintext, &prepared, armor, sign_with)?;
+
+    let dest_label = write_payload(&dest, &ciphertext)?;
+
+    match sign_with {
+        Some(id) => eprintln!(
+            "tcli: Encrypted to {} recipient(s), signed with {}",
+            recipients.len(),
+            id
+        ),
+        None => eprintln!("tcli: Encrypted to {} recipient(s)", recipients.len()),
+    }
+    eprintln!("tcli: Wrote ciphertext to {}", dest_label);
+    Ok(())
+}
+
+/// Resolve the output destination.
+///
+/// - `-o -` → stdout.
+/// - `-o PATH` → that path.
+/// - absent → sibling `<input>.asc` (armored) or `<input>.gpg` (binary).
+///   Reading from stdin with no `-o` is rejected at parse time, but a
+///   hard safety net stays here.
+fn encrypt_destination(
+    input: &Path,
+    output: Option<&PathBuf>,
+    binary: bool,
+) -> Result<Destination> {
+    if let Some(out) = output {
+        if is_stdio(out) {
+            return Ok(Destination::Stdout);
+        }
+        return Ok(Destination::Path(out.clone()));
+    }
+
+    if is_stdio(input) {
+        bail!("reading from stdin requires -o/--output");
+    }
+
+    // Armored encrypted output uses `.asc`, binary uses `.gpg` — matching
+    // GnuPG's own sibling-file conventions.
+    let ext = if binary { "gpg" } else { "asc" };
+    let mut path = input.to_path_buf();
+    let new_name = match path.file_name() {
+        Some(name) => {
+            let mut n = name.to_os_string();
+            n.push(".");
+            n.push(ext);
+            n
+        }
+        None => bail!("input path has no filename: {}", input.display()),
+    };
+    path.set_file_name(new_name);
+    Ok(Destination::Path(path))
+}
+
+#[derive(Debug)]
+enum Destination {
+    Path(PathBuf),
+    Stdout,
+}
+
+fn write_payload(dest: &Destination, bytes: &[u8]) -> Result<String> {
+    match dest {
+        Destination::Path(p) => {
+            std::fs::write(p, bytes).with_context(|| format!("Failed to write {}", p.display()))?;
+            Ok(p.display().to_string())
+        }
+        Destination::Stdout => {
+            std::io::stdout()
+                .write_all(bytes)
+                .context("Failed to write to stdout")?;
+            Ok("stdout".to_string())
+        }
+    }
+}
+
+fn read_input(input: &Path) -> Result<Vec<u8>> {
+    use std::io::Read;
+    if is_stdio(input) {
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .context("Failed to read from stdin")?;
+        Ok(buf)
+    } else {
+        std::fs::read(input).with_context(|| format!("Failed to read {}", input.display()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use wecanencrypt::create_key_simple;
+
+    /// Default sibling path for armored output is `<input>.asc`.
+    #[test]
+    fn default_destination_armored_is_asc() {
+        let dest = encrypt_destination(Path::new("msg.txt"), None, false).unwrap();
+        match dest {
+            Destination::Path(p) => assert_eq!(p, PathBuf::from("msg.txt.asc")),
+            Destination::Stdout => panic!("expected a file path, got stdout"),
+        }
+    }
+
+    /// Default sibling path for binary output is `<input>.gpg`.
+    #[test]
+    fn default_destination_binary_is_gpg() {
+        let dest = encrypt_destination(Path::new("msg.txt"), None, true).unwrap();
+        match dest {
+            Destination::Path(p) => assert_eq!(p, PathBuf::from("msg.txt.gpg")),
+            Destination::Stdout => panic!("expected a file path, got stdout"),
+        }
+    }
+
+    /// `-o -` selects stdout regardless of armor.
+    #[test]
+    fn dash_output_selects_stdout() {
+        let dash = PathBuf::from("-");
+        let dest = encrypt_destination(Path::new("msg.txt"), Some(&dash), false).unwrap();
+        assert!(matches!(dest, Destination::Stdout));
+    }
+
+    /// Explicit `-o PATH` overrides the sibling default.
+    #[test]
+    fn explicit_output_overrides_default() {
+        let out = PathBuf::from("/tmp/ct.bin");
+        let dest = encrypt_destination(Path::new("msg.txt"), Some(&out), true).unwrap();
+        match dest {
+            Destination::Path(p) => assert_eq!(p, out),
+            Destination::Stdout => panic!("expected a file path, got stdout"),
+        }
+    }
+
+    /// Reading from stdin with no `-o` is a hard error here (the parser
+    /// also rejects it, but the safety net must hold).
+    #[test]
+    fn stdin_without_output_errors() {
+        let err = encrypt_destination(Path::new("-"), None, false).unwrap_err();
+        assert!(err.to_string().contains("requires -o/--output"));
+    }
+
+    /// End-to-end: encrypt a file to a known recipient, then decrypt it
+    /// back with that recipient's software secret key. Pins the
+    /// human-facing `cmd_encrypt` happy path through the shared
+    /// `prepare_recipients` + `encrypt_bytes_prepared` core to a real
+    /// round-trip.
+    #[test]
+    fn encrypt_round_trips_to_recipient() {
+        let dir = TempDir::new().unwrap();
+        let ks_path = dir.path().join("keys.db");
+        let pt_path = dir.path().join("plain.txt");
+        let ct_path = dir.path().join("plain.txt.asc");
+        std::fs::write(&pt_path, b"round trip me").unwrap();
+
+        // Recipient (Bob) with a secret so we can decrypt to verify.
+        let bob = create_key_simple("pw", &["Bob <bob@example.com>"]).unwrap();
+        let keystore = wecanencrypt::KeyStore::open(&ks_path).unwrap();
+        keystore.import_key(&bob.secret_key).unwrap();
+        drop(keystore);
+
+        cmd_encrypt(
+            &pt_path,
+            &["bob@example.com".to_string()],
+            None,
+            false, // armored
+            None,  // default sibling path => plain.txt.asc
+            Some(&ks_path),
+        )
+        .unwrap();
+
+        assert!(ct_path.exists(), "ciphertext sibling file must be written");
+        let ciphertext = std::fs::read(&ct_path).unwrap();
+        // Armored output starts with the OpenPGP message header.
+        assert!(
+            ciphertext.starts_with(b"-----BEGIN PGP MESSAGE-----"),
+            "default output should be ASCII-armored"
+        );
+
+        let passphrase: libtumpa::Passphrase = zeroize::Zeroizing::new("pw".to_string());
+        let plaintext =
+            libtumpa::decrypt::decrypt_with_key(&bob.secret_key, &ciphertext, &passphrase)
+                .expect("decrypt should succeed");
+        assert_eq!(&*plaintext, b"round trip me");
+    }
+
+    /// Unknown recipient aborts and writes no output file.
+    #[test]
+    fn unknown_recipient_writes_no_output() {
+        let dir = TempDir::new().unwrap();
+        let ks_path = dir.path().join("keys.db");
+        let pt_path = dir.path().join("plain.txt");
+        let ct_path = dir.path().join("plain.txt.asc");
+        std::fs::write(&pt_path, b"secret").unwrap();
+        // Empty keystore so the recipient cannot resolve.
+        wecanencrypt::KeyStore::open(&ks_path).unwrap();
+
+        let err = cmd_encrypt(
+            &pt_path,
+            &["nobody@example.com".to_string()],
+            None,
+            false,
+            None,
+            Some(&ks_path),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("nobody@example.com"));
+        assert!(
+            !ct_path.exists(),
+            "no output should be written when a recipient is invalid"
+        );
+    }
+
+    /// Invalid recipients are reported before reading plaintext, so a
+    /// bad recipient on stdin cannot hang waiting for input.
+    #[test]
+    fn unknown_recipient_fails_before_reading_input() {
+        let dir = TempDir::new().unwrap();
+        let ks_path = dir.path().join("keys.db");
+        let missing_input = dir.path().join("missing.txt");
+        wecanencrypt::KeyStore::open(&ks_path).unwrap();
+
+        let err = cmd_encrypt(
+            &missing_input,
+            &["nobody@example.com".to_string()],
+            None,
+            false,
+            None,
+            Some(&ks_path),
+        )
+        .unwrap_err();
+
+        let err = err.to_string();
+        assert!(err.contains("nobody@example.com"), "got: {err}");
+        assert!(!err.contains("Failed to read"), "got: {err}");
+    }
+}

--- a/src/gpg/decrypt.rs
+++ b/src/gpg/decrypt.rs
@@ -34,11 +34,41 @@ fn read_ciphertext(input: &Path) -> Result<Vec<u8>> {
     }
 }
 
+/// Write decrypted plaintext to `output`, or to stdout when `output` is
+/// `None` or the `-` stdio sentinel.
+///
+/// GnuPG treats `-o -` as "write to stdout"; mirroring that here means
+/// `tclig -d -o -` (and `tcli decrypt -o -`) stream to stdout instead of
+/// creating a file literally named `-`. File output is tightened to
+/// `0600` on Unix.
+fn write_plaintext(output: Option<&PathBuf>, plaintext: &[u8]) -> Result<()> {
+    match output {
+        Some(path) if path.as_os_str() != "-" => {
+            std::fs::write(path, plaintext)
+                .context(format!("Failed to write output file {:?}", path))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = std::fs::Permissions::from_mode(0o600);
+                std::fs::set_permissions(path, perms).with_context(|| {
+                    format!("Failed to set permissions on output file {:?}", path)
+                })?;
+            }
+        }
+        _ => {
+            std::io::stdout()
+                .write_all(plaintext)
+                .context("Failed to write to stdout")?;
+        }
+    }
+    Ok(())
+}
+
 /// Decrypt a file.
 ///
 /// Reads ciphertext from `input`, determines which secret key can decrypt
 /// it, prompts for the passphrase, and writes plaintext to `output`
-/// (or stdout if None).
+/// (or stdout if None or `-`).
 pub fn decrypt(
     input: &Path,
     output: Option<&PathBuf>,
@@ -68,23 +98,7 @@ pub fn decrypt(
         }
     };
 
-    match output {
-        Some(path) => {
-            std::fs::write(path, plaintext.as_slice())
-                .context(format!("Failed to write output file {:?}", path))?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let perms = std::fs::Permissions::from_mode(0o600);
-                std::fs::set_permissions(path, perms).ok();
-            }
-        }
-        None => {
-            std::io::stdout()
-                .write_all(plaintext.as_slice())
-                .context("Failed to write to stdout")?;
-        }
-    }
+    write_plaintext(output, plaintext.as_slice())?;
 
     Ok(())
 }
@@ -226,23 +240,7 @@ pub fn decrypt_and_verify(
     // Write plaintext first, then status lines — that way a downstream
     // pipe consumer that closes early on signature status doesn't lose
     // data. (PGP/MIME callers buffer both anyway.)
-    match output {
-        Some(path) => {
-            std::fs::write(path, result.plaintext.as_slice())
-                .context(format!("Failed to write output file {:?}", path))?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let perms = std::fs::Permissions::from_mode(0o600);
-                std::fs::set_permissions(path, perms).ok();
-            }
-        }
-        None => {
-            std::io::stdout()
-                .write_all(result.plaintext.as_slice())
-                .context("Failed to write to stdout")?;
-        }
-    }
+    write_plaintext(output, result.plaintext.as_slice())?;
 
     writeln!(status_out, "[GNUPG:] DECRYPTION_OKAY")?;
     emit_signature_status(&mut status_out, &result.outcome)?;
@@ -623,5 +621,43 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Serializes the two tests below that change the process-global
+    /// current directory.
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// A real output path is written verbatim (and, on Unix, gets 0600).
+    #[test]
+    fn write_plaintext_real_path_writes_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let out = dir.path().join("plain.txt");
+        write_plaintext(Some(&out), b"hello").unwrap();
+        assert_eq!(std::fs::read(&out).unwrap(), b"hello");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&out).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "decrypt output must be 0600");
+        }
+    }
+
+    /// `-o -` must stream to stdout (GnuPG convention), not create a file
+    /// literally named "-". Regression guard for the `tclig -d -o -`
+    /// path the reviewer flagged. The cwd is swapped to a temp dir so the
+    /// relative "-" check is hermetic.
+    #[test]
+    fn write_plaintext_dash_is_stdout_not_a_file() {
+        let _g = CWD_LOCK.lock().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let res = write_plaintext(Some(&PathBuf::from("-")), b"hello");
+        std::env::set_current_dir(&prev).unwrap();
+        res.unwrap();
+        assert!(
+            !dir.path().join("-").exists(),
+            "`-` must go to stdout, not a file named -"
+        );
     }
 }

--- a/src/gpg/encrypt.rs
+++ b/src/gpg/encrypt.rs
@@ -64,8 +64,43 @@ pub fn encrypt_with_status(
     armor: bool,
     signer_id: Option<&str>,
     keystore_path: Option<&PathBuf>,
-    mut status_out: impl Write,
+    status_out: impl Write,
 ) -> Result<()> {
+    let prepared = prepare_recipients(recipients, keystore_path, status_out)?;
+
+    let plaintext = match input {
+        Some(path) => {
+            std::fs::read(path).context(format!("Failed to read input file {:?}", path))?
+        }
+        None => {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            buf
+        }
+    };
+
+    let ciphertext = encrypt_bytes_prepared(&plaintext, &prepared, armor, signer_id)?;
+
+    std::fs::write(output, &ciphertext)
+        .context(format!("Failed to write output file {:?}", output))?;
+
+    Ok(())
+}
+
+pub struct PreparedRecipients {
+    keystore: wecanencrypt::KeyStore,
+    keys: Vec<Vec<u8>>,
+}
+
+/// Resolve recipients and emit all `INV_RECP` status lines before any
+/// caller reads plaintext from stdin or large files.
+pub fn prepare_recipients(
+    recipients: &[String],
+    keystore_path: Option<&PathBuf>,
+    mut status_out: impl Write,
+) -> Result<PreparedRecipients> {
     let keystore = store::open_keystore(keystore_path)?;
 
     // Resolve all recipients up front so we can emit INV_RECP for each
@@ -96,32 +131,32 @@ pub fn encrypt_with_status(
         anyhow::bail!("no usable key for recipient(s): {}", failed.join(", "));
     }
 
-    let plaintext = match input {
-        Some(path) => {
-            std::fs::read(path).context(format!("Failed to read input file {:?}", path))?
-        }
-        None => {
-            let mut buf = Vec::new();
-            std::io::stdin()
-                .read_to_end(&mut buf)
-                .context("Failed to read from stdin")?;
-            buf
-        }
-    };
+    Ok(PreparedRecipients {
+        keystore,
+        keys: resolved,
+    })
+}
 
-    let key_refs: Vec<&[u8]> = resolved.iter().map(|d| d.as_slice()).collect();
+/// Encrypt already-read plaintext using recipients returned by
+/// [`prepare_recipients`].
+pub fn encrypt_bytes_prepared(
+    plaintext: &[u8],
+    prepared: &PreparedRecipients,
+    armor: bool,
+    signer_id: Option<&str>,
+) -> Result<Vec<u8>> {
+    let keystore = &prepared.keystore;
+
+    let key_refs: Vec<&[u8]> = prepared.keys.iter().map(|d| d.as_slice()).collect();
 
     let ciphertext = match signer_id {
-        Some(id) => sign_and_encrypt_dispatch(&keystore, id, &key_refs, &plaintext, armor)?,
-        None => wecanencrypt::encrypt_bytes_to_multiple(&key_refs, &plaintext, armor)
+        Some(id) => sign_and_encrypt_dispatch(keystore, id, &key_refs, plaintext, armor)?,
+        None => wecanencrypt::encrypt_bytes_to_multiple(&key_refs, plaintext, armor)
             .map_err(|e| anyhow!("{e}"))
             .context("Encryption failed")?,
     };
 
-    std::fs::write(output, &ciphertext)
-        .context(format!("Failed to write output file {:?}", output))?;
-
-    Ok(())
+    Ok(ciphertext)
 }
 
 /// Resolve `signer_id`, dispatch the signing leg to a connected card when

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ pub mod cache_cmd;
 pub mod card_link;
 pub mod card_touch;
 pub mod cli;
+pub mod decrypt_cmd;
+pub mod encrypt_cmd;
 pub mod gpg;
 pub mod keystore;
 pub mod list_cards;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,10 @@ use std::io::stdout;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use tumpa_cli::{cache_cmd, card_link, keystore, pinentry, sign_cmd, ssh, store, verify_cmd};
+use tumpa_cli::{
+    cache_cmd, card_link, decrypt_cmd, encrypt_cmd, keystore, pinentry, sign_cmd, ssh, store,
+    verify_cmd,
+};
 
 use cli::*;
 
@@ -128,6 +131,23 @@ fn main() {
             with_key,
             output,
         }) => sign_cmd::cmd_sign_inline(&input, &with_key, output.as_ref(), keystore_path.as_ref()),
+        Ok(Mode::Encrypt {
+            input,
+            recipients,
+            sign_with,
+            binary,
+            output,
+        }) => encrypt_cmd::cmd_encrypt(
+            &input,
+            &recipients,
+            sign_with.as_deref(),
+            binary,
+            output.as_ref(),
+            keystore_path.as_ref(),
+        ),
+        Ok(Mode::Decrypt { input, output }) => {
+            decrypt_cmd::cmd_decrypt(&input, output.as_ref(), keystore_path.as_ref())
+        }
         Ok(Mode::CacheClear { target }) => cache_cmd::cmd_cache_clear(target.as_deref()),
         Ok(Mode::Verify {
             input,

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -105,9 +105,7 @@ pub fn touch_prompt(op: TouchOp, card_serial: Option<&str>) {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
         let (headline, supporting) = render(op, card_serial);
-        log::info!(
-            "touch banner: op={op:?} headline={headline:?} body={supporting:?}"
-        );
+        log::info!("touch banner: op={op:?} headline={headline:?} body={supporting:?}");
 
         #[cfg(target_os = "macos")]
         post_macos(&headline, &supporting);


### PR DESCRIPTION
Add human-facing `tcli encrypt`/`tcli decrypt` verbs, completing the tcli (human) / tclig (gpg drop-in) split. encrypt defaults to armored <FILE>.asc, supports multiple -r recipients and optional --sign-with; decrypt writes stdout by default or a 0600 file with -o. Both are card-first with software fallback, reusing the shared gpg encrypt core.

Also bump libtumpa 0.3.2 -> 0.4.2, add ADR 0010, docs, and tests.

Bug fixes:
- tclig encrypt resolves recipients and emits INV_RECP before reading plaintext, so an invalid recipient fails fast instead of blocking on stdin.
- decrypt treats `-o -` as stdout instead of writing a file named "-".

This also fixes #32 due to the updated wecanencrypt.